### PR TITLE
Add ability to make titles dynamic

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,9 +104,13 @@ class Router extends React.Component {
                     self.setState({initialRoute: child.props});
                 }
                 if (!(RouterActions[name])) {
-                    RouterActions[name] = function (data) {
+                    RouterActions[name] = function (data, dynamicTitle) {
                         if (typeof(data)!='object'){
                             data={data:data};
+                        }
+                        if(dynamicTitle){
+                            var updatedRoute = Object.assign({}, self.routes[name], {title: dynamicTitle});
+                            self.routes[name] = updatedRoute;
                         }
                         var args = {name: name, data:data};
                         RouterActions.push(args);


### PR DESCRIPTION
In our app, all of the navbar titles aren't static. We have a few places where we're putting the users name or the title of the specific post in the title. This pull request makes it possible to dynamically update the routes title by passing in the name of the title as the second argument to ```Animation.myRoute```. 

![rfbis7azsv](https://cloud.githubusercontent.com/assets/2933430/9661762/1e86c08a-5254-11e5-8ce8-94829c165ab1.gif)

The code for the above Gif looks like this,

```
    Actions.post({
      authedUser: this.props.authedUser,
      post: this.props.post
    }, this.getTitle(this.props.post.title));
```