### PR TITLE
Add string names to avoid obfuscation

### DIFF
--- a/FetchActions.js
+++ b/FetchActions.js
@@ -1,6 +1,6 @@
 var alt = require('./alt');
 
-class Actions {
+class FetchActions {
     fetch(route, data){
         this.dispatch({route, data});
     }
@@ -23,4 +23,4 @@ class Actions {
 }
 
 
-module.exports = alt.createActions(Actions);
+module.exports = alt.createActions(FetchActions, "FetchActions");

--- a/actions.js
+++ b/actions.js
@@ -7,4 +7,4 @@ class Actions {
     }
 }
 
-module.exports = alt.createActions(Actions);
+module.exports = alt.createActions(Actions, "Actions");

--- a/store.js
+++ b/store.js
@@ -52,4 +52,4 @@ class RouterStore {
 }
 
 
-module.exports = alt.createStore(RouterStore);
+module.exports = alt.createStore(RouterStore, "RouterStore");


### PR DESCRIPTION
Uglify tends to obfuscate class names. Adding a string to the
alt.createXXX methods tends to help.

Hopefully helps with https://github.com/aksonov/react-native-router-flux/issues/4 