### PR TITLE
fix iOS demo[bundle url & packager failed with npm start]

### DIFF
--- a/Example/iOS/AppDelegate.m
+++ b/Example/iOS/AppDelegate.m
@@ -31,7 +31,7 @@
    * on the same Wi-Fi network.
    */
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle"];
+  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios"];
 
   /**
    * OPTION 2
@@ -49,7 +49,7 @@
                                                       moduleName:@"Example"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
-  
+
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [[UIViewController alloc] init];
   rootViewController.view = rootView;

--- a/Example/package.json
+++ b/Example/package.json
@@ -6,7 +6,7 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react-native": "^0.11.4",
+    "react-native": "^0.13.2",
     "react-native-button": "^1.2.1",
     "react-native-navbar": "^0.8.0",
     "react-native-router-flux": "^0.3.2",


### PR DESCRIPTION
Examples cannot run for 2 reasons:
1. packager cannot start(npm start failed). <-- fix by using up-to-date version of react-native
more from here: https://github.com/facebook/react-native/issues/1758
2. run ios project failed <-- fix by change the jsCodeLocation bundle url (appending "?platform=ios")