### PR TITLE
clear 'npm install' artifacts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,16 +23,6 @@
     "url": "http://aksonov.com"
   },
   "license": "ISC",
-  "gitHead": "ac054cfda0894ba1db6c4901ebdddc83b3b2d083",
-  "_id": "react-native-router-flux@0.3.3",
-  "_shasum": "074748258f7ff6b6d7e2d509123d15a8ec84cb45",
-  "_from": "react-native-router-flux@0.3.3",
-  "_npmVersion": "2.13.2",
-  "_nodeVersion": "2.5.0",
-  "_npmUser": {
-    "name": "aksonov",
-    "email": "pavlo.aksonov@gmail.com"
-  },
   "maintainers": [
     {
       "name": "aksonov",


### PR DESCRIPTION
This project was likely started by running "npm install" to get its source.
In `package.json` there were fields, which are normally not part of package.json,
but npm adds them when it 'npm install's some dependency.
This PR removes those generated fields (which should not be present in normal project package.json).
