### PR TITLE
Use `initialRouteStack` instead of `initialRoute`

### DIFF
--- a/Example/Example.js
+++ b/Example/Example.js
@@ -22,13 +22,13 @@ class TabIcon extends React.Component {
 export default class Example extends React.Component {
     render() {
         return (
-            <Router hideNavBar={true}>
+            <Router hideNavBar={true} initialRoutes={['launch', 'login']}>
                 <Schema name="modal" sceneConfig={Navigator.SceneConfigs.FloatFromBottom}/>
                 <Schema name="default" sceneConfig={Navigator.SceneConfigs.FloatFromRight}/>
                 <Schema name="withoutAnimation"/>
                 <Schema name="tab" type="switch" icon={TabIcon} />
 
-                <Route name="launch" component={Launch} initial={true} wrapRouter={true} title="Launch" hideNavBar={true}/>
+                <Route name="launch" component={Launch} wrapRouter={true} title="Launch" hideNavBar={true}/>
                 <Route name="register" component={Register} title="Register"/>
                 <Route name="home" component={Home} title="Replace" type="replace"/>
                 <Route name="login" schema="modal">

--- a/Example/iOS/AppDelegate.m
+++ b/Example/iOS/AppDelegate.m
@@ -47,7 +47,7 @@
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"Example"
-                                               initialProperties:nil
+                                               initialProperties:@{@"initialRoutes": @[@"launch", @"login"]}
                                                    launchOptions:launchOptions];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/index.js
+++ b/index.js
@@ -456,7 +456,7 @@ class Router extends React.Component {
         super(props);
         this.routes = {};
         this.schemas = {...props.schemas};
-        this.initial = props.initial;
+        this.initial = this.props.initialRoutes || []; // Initial names array
 
         const self = this;
         React.Children.forEach(this.props.children, function (child, index) {
@@ -468,8 +468,8 @@ class Router extends React.Component {
         React.Children.forEach(this.props.children, function (child, index) {
             const name = child.props.name;
             if (child.type.prototype.className() === "Route") {
-                if (child.props.initial || !self.initial) {
-                    self.initial = name;
+                if (child.props.initial) {
+                    self.initial.push(name);
                 }
                 // declare function with null navigator to avoid undefined Actions
                 Actions.addAction(name, child.props, self.schemas, self)
@@ -496,12 +496,12 @@ class Router extends React.Component {
     }
 
     render(){
-        if (!this.state.initial){
+        if (!this.state.initial.length){
             console.error("No initial attribute!");
         }
-        const initialRoute =  this.routes[this.state.initial];
-        if (!initialRoute) {
-            console.error("No initial route!"+JSON.stringify(this.routes));
+        const initialRoutes =  this.state.initial.map((name) => this.routes[name]);
+        if (!initialRoutes.length) {
+            console.error("No initial routes!"+JSON.stringify(this.routes));
         }
 
         const Header = this.props.header;
@@ -514,7 +514,7 @@ class Router extends React.Component {
             <View style={styles.transparent}>
                 {header}
                 <ExNavigator ref="nav"
-                             initialRoute={new ExRoute(initialRoute, this.schemas)}
+                             initialRouteStack={initialRoutes.map((route) => new ExRoute(route, this.schemas))}
                              style={styles.transparent}
                              sceneStyle={{ paddingTop: 0 }}
                              showNavigationBar={!this.props.hideNavBar}


### PR DESCRIPTION
I have encountered a problem when use react-native-router-flux. Consider such a scenario: When launching the app the first time, the "launch" page is presented; However, when user have registered an account, the "login" page should be presented and user is able to go back to "launch" page as well.  

I've tried some workaround but it doesn't work well. So I come up with this idea. It adds a props `initialRoutes` to `Router`, which is an array contains the initial routes' name. And those names will be used to generate the `initialRouteStack` of `ExNavigator`.