### PR TITLE
Fallback on navigator.props._parent when parentNavigator is not found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -553,7 +553,7 @@ class Router extends React.Component {
                 <ExNavigator ref="nav"
                              initialRouteStack={initialRoutes.map((route) => new ExRoute(route, this.schemas))}
                              style={styles.transparent}
-                             sceneStyle={{ paddingTop: 0 }}
+                             sceneStyle={{ paddingTop: 0, backgroundColor: 'transparent' }}
                              showNavigationBar={!this.props.hideNavBar}
                     {...this.props}
 

--- a/index.js
+++ b/index.js
@@ -210,11 +210,17 @@ class ActionContainer {
         //console.log("NAV LATEST SCENE:"+routes[routes.length-1].getName()+" "+routes.length);
         while (routes.length <= number || routes[routes.length-1].getType() === 'switch'){
             // try parent navigator if we cannot pop current one
-            if (navigator.parentNavigator){
+            var parentNavigator = navigator.parentNavigator;
+            if ( ! parentNavigator) {
+              parentNavigator = this.navs[navigator.props._parent];
+            }
+
+            if (parentNavigator) {
                 //console.log("pop to parent navigator");
-                navigator = navigator.parentNavigator;
+                navigator = parentNavigator;
                 routes = navigator.getCurrentRoutes();
-            } else {
+            }
+            else {
                 throw new Error("Cannot pop navigator with less than "+number+" screens");
             }
         }


### PR DESCRIPTION
Hi,

For my app, I wrapped a nested Router inside another view (for eg. SideMenu) but it caused all nested route navigation to not work properly. Going through the code, I found out that this was because the nested router was failing to reference the parent navigator when it wasn't a direct child. The issue was thus easily resolved by referencing _parent,

```jsx
<Router hideNavBar={true}>
  <Schema ... />
  <Route name="login" ... />
  <Route name="home" ... >
    <SideMenu ...>
      <Router _parent="home" ...>
        <Route name="feed" ... />
      </Router>
    </SideMenu>
  </Route>
</Router>
```

However, now when I call ```Actions.pop``` from the **feed** route, it fails throwing ```JS Exception: Cannot pop navigator with less than 1 screens``` exception. For this, I had to change the Actions.pop method as follows,

```diff
+            var parentNavigator = navigator.parentNavigator;
+            if ( ! parentNavigator) {
+              parentNavigator = this.navs[navigator.props._parent];
+            }

-            if (navigator.parentNavigator) {
+            if (parentNavigator) {
                //console.log("pop to parent navigator");
-                navigator = navigator.parentNavigator;
+               navigator = parentNavigator;
                routes = navigator.getCurrentRoutes();
            } else {
                throw new Error("Cannot pop navigator with less than "+number+" screens");
            }
```

Are there any side-effects to this? Let me know if I can improve on it.

Regards,
Basit