### PR TITLE
Added popToTop() in the onReplace method

### DIFF
--- a/ExRouter.js
+++ b/ExRouter.js
@@ -202,6 +202,7 @@ export default class ExRouter extends React.Component {
                 return false;
             }
         }
+        this.refs.nav.popToTop();
         this.refs.nav.replace(new ExRouteAdapter(route, props));
         return true;
     }


### PR DESCRIPTION
Added `this.refs.nav.popToTop()` to the onReplace method of `ExRouter.js` so that the components **unmount** when replacing the current route with another route.  I was having an issue where one of my child routes that requires an event listener wasn't having it's `componentWillUnmount` called when replacing the route.  This change is working for my use case.

I'm new to this package so there may be a better way to solve this.