### PR TITLE
Clears Actions.currentRouter when unmounting ExRouter if this is the …

### DIFF
--- a/ExRouter.js
+++ b/ExRouter.js
@@ -187,6 +187,12 @@ export default class ExRouter extends React.Component {
         this.state = {};
     }
 
+    componentWillUnmount() {
+        if (this === Actions.currentRouter.delegate) {
+            Actions.currentRouter = null;
+        }
+    }
+
     onPush(route: Route, props:{ [key: string]: any}):boolean {
         if (this.props.onPush){
             const res = this.props.onPush(route, props);


### PR DESCRIPTION
…current router's ExRouter instance. Fixes #172 

I hope it doesn't have undesired side effects ;) but I took care of only clearing it if it is the current router's ExRouter.

What do you think, @aksonov?