### PR TITLE
Get rid off white flickering line that appears underneath router header

### DIFF
--- a/ExRouter.js
+++ b/ExRouter.js
@@ -294,7 +294,7 @@ export default class ExRouter extends React.Component {
                 {header}
                 <ExNavigator ref="nav" initialRouteStack={router.stack.map(route => new ExRouteAdapter(router.routes[route]))}
                          style={styles.transparent}
-                         sceneStyle={{ paddingTop: 0 }}
+                         sceneStyle={{ paddingTop: 0, backgroundColor:'transparent' }}
                          renderNavigationBar={props=><ExNavigationBar {...props} router={router}/>}
                     {...this.props}
                 />


### PR DESCRIPTION
I am using custom header component that has dark background. When I `pop` modal scene there is almost always a white flickering line underneath the header.

This is a workaround that fixes the issue.
Also there is a github issue for that in RN https://github.com/facebook/react-native/issues/3375