### PR TITLE
Add BEFORE_FOCUS and AFTER_FOCUS for swipe gesture handling.

### DIFF
--- a/Actions.js
+++ b/Actions.js
@@ -8,6 +8,8 @@ const BEFORE_POP = 'BEFORE_ROUTER_POP';
 const AFTER_POP = 'AFTER_ROUTER_POP';
 const BEFORE_DISMISS = 'BEFORE_ROUTER_DISMISS';
 const AFTER_DISMISS = 'AFTER_ROUTER_DISMISS';
+const AFTER_FOCUS = 'AFTER_ROUTER_FOCUS';
+const BEFORE_FOCUS = 'BEFORE_ROUTER_FOCUS';
 
 function isNumeric(n){
     return !isNaN(parseFloat(n)) && isFinite(n);
@@ -152,4 +154,6 @@ actions.BEFORE_POP = BEFORE_POP;
 actions.AFTER_POP = AFTER_POP;
 actions.BEFORE_DISMISS = BEFORE_DISMISS;
 actions.AFTER_DISMISS = AFTER_DISMISS;
+actions.BEFORE_FOCUS = BEFORE_FOCUS;
+actions.AFTER_FOCUS = AFTER_FOCUS;
 export default actions;

--- a/Router.js
+++ b/Router.js
@@ -30,27 +30,29 @@ export default class Router extends React.Component {
     componentDidMount(){
         this.router.delegate = this.refs.router;
 
-        this.router.delegate.refs.nav.navigationContext.addListener('willfocus', function (ev) {
-          let name = ev.data.route.name;
-          let title = ev.data.route.title;
+        if (this.props.dispatch) {
+          this.router.delegate.refs.nav.navigationContext.addListener('willfocus', function (ev) {
+            let name = ev.data.route.name;
+            let title = ev.data.route.title;
 
-          this.props.dispatch({
-            type: Actions.BEFORE_FOCUS,
-            name: name,
-            title: title
-          });
-        }.bind(this));
+            this.props.dispatch({
+              type: Actions.BEFORE_FOCUS,
+              name: name,
+              title: title
+            });
+          }.bind(this));
 
-        this.router.delegate.refs.nav.navigationContext.addListener('didfocus', function (ev) {
-          let name = ev.data.route.name;
-          let title = ev.data.route.title;
+          this.router.delegate.refs.nav.navigationContext.addListener('didfocus', function (ev) {
+            let name = ev.data.route.name;
+            let title = ev.data.route.title;
 
-          this.props.dispatch({
-            type: Actions.AFTER_FOCUS,
-            name: name,
-            title: title
-          });
-        }.bind(this));
+            this.props.dispatch({
+              type: Actions.AFTER_FOCUS,
+              name: name,
+              title: title
+            });
+          }.bind(this));
+        }
     }
 
     render(){

--- a/Router.js
+++ b/Router.js
@@ -29,6 +29,28 @@ export default class Router extends React.Component {
 
     componentDidMount(){
         this.router.delegate = this.refs.router;
+
+        this.router.delegate.refs.nav.navigationContext.addListener('willfocus', function (ev) {
+          let name = ev.data.route.name;
+          let title = ev.data.route.title;
+
+          this.props.dispatch({
+            type: Actions.BEFORE_FOCUS,
+            name: name,
+            title: title
+          });
+        }.bind(this));
+
+        this.router.delegate.refs.nav.navigationContext.addListener('didfocus', function (ev) {
+          let name = ev.data.route.name;
+          let title = ev.data.route.title;
+
+          this.props.dispatch({
+            type: Actions.AFTER_FOCUS,
+            name: name,
+            title: title
+          });
+        }.bind(this));
     }
 
     render(){


### PR DESCRIPTION
See #197.

There is currently no handler for swipe gesture navigation.

This PR allows us to do the following:

~~~js
import { createReducer } from 'redux-immutablejs';
import {Actions} from 'react-native-router-flux';
const {
  AFTER_FOCUS,
  BEFORE_FOCUS,
} = Actions;

function updateCurrentRoute (state, {name}) {
  return state.set('currentRouteName', name);
}

// this will happen after any navigation action is performed
export default createReducer(initialState, {
  [AFTER_FOCUS]: updateCurrentRoute,
});
~~~

This has the added benefit of serving as a catch-all for all route changes. For example, instead of  handling `AFTER_ROUTE`, `AFTER_POP`, and `AFTER_DISMISS` actions separately, we can simply use `AFTER_FOCUS` instead. 

And similarly, `BEFORE_FOCUS` can be used instead of `BEFORE_*`.