### PR TITLE
NoTransition scene config causes blank scenes

### DIFF
--- a/Animations.js
+++ b/Animations.js
@@ -4,13 +4,8 @@ import buildStyleInterpolator from 'react-native/Libraries/Utilities/buildStyleI
 
 var NoTransition = {
     opacity: {
-        from: 1,
-        to: 1,
-        min: 1,
-        max: 1,
-        type: 'linear',
-        extrapolate: false,
-        round: 100,
+        value: 1.0,
+        type: 'constant',
     },
 };
 


### PR DESCRIPTION
The NoTransition scene config produces an interpolator function with a
divide by zero, which can cause scenes to have opacity=NaN when
directionAdjustedProgress is set to 1.

This bad value is interpreted on Simulator as opacity=1 (bug does not
appear) but on my device it shows up as opacity=0 (scene shows briefly and
then disappears).

The 'constant' type seems more appropriate here.

fixes #174 