### PR TITLE
Added missing defaultRoute action to tabbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ export default class Example extends React.Component {
                 <Route name="register2" component={Register} title="Register2"  schema="withoutAnimation"/>
                 <Route name="tabbar">
                     <Router footer={TabBar} hideNavBar={true} tabBarStyle={{borderTopColor:'#00bb00',borderTopWidth:1,backgroundColor:'white'}}>
-                        <Route name="tab1" schema="tab" title="Tab #1" >
+                        <Route name="tab1" schema="tab" title="Tab #1" defaultRoute='tab1_1'>
                             <Router>
                                 <Route name="tab1_1" component={TabView} title="Tab #1_1" />
                                 <Route name="tab1_2" component={TabView} title="Tab #1_2" />

--- a/TabBar.js
+++ b/TabBar.js
@@ -8,8 +8,11 @@ export default class TabBar extends React.Component {
         if (!Actions[el.props.name]){
             throw new Error("No action is defined for name="+el.props.name+" actions:"+JSON.stringify(Object.keys(Actions)));
         }
-        Actions[el.props.name]({hideTabBar: el.props.hideTabBar});
-
+        if (this.props.selected == el.props.name && Actions[el.props.defaultRoute]) {
+            Actions[el.props.defaultRoute]({hideTabBar: el.props.hideTabBar});
+        } else {
+            Actions[el.props.name]({hideTabBar: el.props.hideTabBar});
+        }
     }
     render(){
         if (this.props.hideTabBar){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-router-flux",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "React Native Router using Flux architecture",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It was deleted in https://github.com/aksonov/react-native-router-flux/commit/5b1225c3dc38b3380017355c727cd46259dc9cf4 but still present in documentation.

Also added an example how to use it.