### PR TITLE
Use route props first when determining route title

### DIFF
--- a/ExRouter.js
+++ b/ExRouter.js
@@ -82,8 +82,9 @@ export class ExRouteAdapter {
     }
 
     getTitle() {
-        debug("TITLE ="+this.route.title+" for route="+this.route.name);
-        return this.title || "";
+        const title = this.route.props.title || this.title || "";
+        debug("TITLE ="+title+" for route="+this.route.name);
+        return title;
     }
 
     getBackButtonTitle(navigator, index, state){


### PR DESCRIPTION
When invoking Actions.refresh({title: 'Changed'}), the call to
super.render() in ExNavigationBar calls back into getTitle() on
ExRouteAdapter to determine the title to display in the navigation bar
This patch first checks the provided props before falling back to the
previous behavior.