### PR TITLE
Added renderBackButton to ExRouter constructor

### DIFF
--- a/ExRouter.js
+++ b/ExRouter.js
@@ -45,6 +45,9 @@ export class ExRouteAdapter {
         if (this.route.props.renderLeftButton){
             this.renderLeftButton = this.route.props.renderLeftButton.bind(this.route);
         }
+        if (this.route.props.renderBackButton){
+            this.renderBackButton = this.route.props.renderBackButton.bind(this.route);
+        }
     }
 
     configureScene() {


### PR DESCRIPTION
Couldn't get renderBackButton to work. After looking at the code, I couldn't find it being assigned anywhere. I added it into the constructor where renderRightButton and renderLeftButton are assigned. Don't know if that's the right place, but that is what got it working for me at least. Let me know if I need to change anything.

Awesome project.