### PR TITLE
Make pop work on invisible component

### DIFF
--- a/Actions.js
+++ b/Actions.js
@@ -118,16 +118,24 @@ class Actions {
         }
         return res;
     }
-    pop(num: number = 1, props: { [key: string]: any} = {}){
+    pop(num: number = 1, props: { [key: string]: any} = {}, parentRouter: BaseRouter = {}){
         props = filterParam(props);
         if (!isNumeric(num)){
             num = 1;
         }
-        if (!this.currentRouter){
-            throw new Error("No current router is set");
+
+        let router:BaseRouter;
+        if (parentRouter) {
+            router = parentRouter;
         }
-     
-        let router: BaseRouter = this.currentRouter;
+        else {
+            if (!this.currentRouter) {
+                throw new Error("No current router is set");
+            }
+
+            router = this.currentRouter;
+        }
+
         debug("Pop, router="+router.name+" stack length:"+router.stack.length);
         debug("Current route="+router.currentRoute.name+" type="+router.currentRoute.type);
         while (router.stack.length <= 1 || router.currentRoute.type === 'switch'){
@@ -142,7 +150,8 @@ class Actions {
             router.delegate.props.dispatch({...props, type: BEFORE_POP, route:router.currentRoute, name:router.currentRoute.name})
         }
         if (router.pop(num, props)){
-            this.currentRouter = router;
+            if (!parentRouter)
+                this.currentRouter = router;
             if (router.delegate.props && router.delegate.props.dispatch){
                 router.delegate.props.dispatch({...props, type: AFTER_POP, route:router.currentRoute, name:router.currentRoute.name})
             }

--- a/Actions.js
+++ b/Actions.js
@@ -118,7 +118,7 @@ class Actions {
         }
         return res;
     }
-    pop(num: number = 1, props: { [key: string]: any} = {}, parentRouter: BaseRouter = {}){
+    pop(num: number = 1, props: { [key: string]: any} = {}, parentRouter: BaseRouter){
         props = filterParam(props);
         if (!isNumeric(num)){
             num = 1;

--- a/Route.js
+++ b/Route.js
@@ -7,6 +7,7 @@
  *
  */
 
+import Actions from './Actions';
 import type BaseRouter from './BaseRouter';
 export default class Route {
     name: string;
@@ -41,7 +42,10 @@ export default class Route {
         this.footer = footer;
         this.props = props;
         this.wrapRouter = wrapRouter || type=='switch';
-
+        this.pop = this.pop.bind(this)
     }
 
+    pop(num: number = 1, props: { [key: string]: any} = {}) {
+        Actions.pop(num, props, this.parent);
+    }
 }


### PR DESCRIPTION
Discussion in https://github.com/aksonov/react-native-router-flux/issues/291. Allows a route to be popped when it's not visible/on top of the current route stack (e.g., when tabbar results in multiple stacks of views).