### PR TITLE
Support deeply nested scenes setting TabBar properties

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -25,6 +25,9 @@ export default class extends Component {
     render(){
         const state = this.props.navigationState;
         const selected = state.children[state.index];
+        while (selected.hasOwnProperty("children")) {
+          selected = selected.children[selected.index]
+        }
         const hideTabBar = state.hideTabBar || selected.hideTabBar;
         return <View style={{flex:1}}>
                     <NavigationView


### PR DESCRIPTION
If a scene is nested too deeply in a component with a tab bar it loses the ability to control the visibility of the tab bar.