### PR TITLE
Fix navigationBarStyle for nested scenes

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -67,7 +67,7 @@ export default class extends React.Component {
         }
         return (
             <Animated.View
-                style={[styles.header, state.navigationBarStyle]}>
+                style={[styles.header, state.navigationBarStyle, selected.navigationBarStyle]}>
                 {state.children.map(this._renderTitle, this)}
                 {this._renderBackButton()}
                 {this._renderLeftButton()}


### PR DESCRIPTION
`navigationBarStyle` wasn't being applied to my nested scenes. This PR fixes use cases like the example below.

```
  <Scene key="root">
    <Scene key="page" component={Page} initial={true} navigationBarStyle={{backgroundColor: 'red'}}/>
  </Scene>
```

In `NavBar.js` [here](https://github.com/aksonov/react-native-router-flux/blob/3168536a7cb46b5b9a02256bb20ece0d072e7550/src/NavBar.js#L53), `state` always referred to the scene with key "root". I've just applied the `navigationBarStyle` from `selected` which references the scene "page" in this example.

I noticed the `navigationBarStyle` was working in the example project but I think that's because it's immediately nested within a tab bar.