### PR TITLE
Added action type: 'pushToCurrent'

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -10,6 +10,7 @@ import assert from 'assert';
 import Scene from './Scene';
 export const JUMP_ACTION = 'jump';
 export const PUSH_ACTION = 'push';
+export const PUSH_TO_CURRENT_ACTION = 'pushToCurrent';
 export const REPLACE_ACTION = 'replace';
 export const POP_ACTION2 = 'back';
 export const POP_ACTION = 'BackAction';
@@ -51,7 +52,7 @@ class Actions {
         assert(root.props, "props should be defined for stack");
         const key = root.key;
         assert(key, "unique key should be defined ",root);
-        assert([POP_ACTION, POP_ACTION2, REFRESH_ACTION, REPLACE_ACTION, JUMP_ACTION, PUSH_ACTION, RESET_ACTION, 'create',
+        assert([POP_ACTION, POP_ACTION2, REFRESH_ACTION, REPLACE_ACTION, JUMP_ACTION, PUSH_ACTION, PUSH_TO_CURRENT_ACTION, RESET_ACTION, 'create',
                 'init','callback','iterate','current'].indexOf(key)==-1, key+" is not allowed as key name");
         const {children, ...staticProps} = root.props;
         let type = root.props.type || (parentProps.tabs ? JUMP_ACTION : PUSH_ACTION);

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -90,14 +90,14 @@ function update(state,action){
 
         case PUSH_TO_CURRENT_ACTION:
             parent = getCurrent(newState).parent;
-            newProps.ephemeral = true;
-            newProps.key = `${_uniqPushed++}$${newProps.key}`;
             newProps.parent = parent;
             el = findElement(newState, parent);
             assert(el, "Cannot find element for parent="+parent+" within current state:"+JSON.stringify(newState));
             // fall through to PUSH_ACTION
 
         case PUSH_ACTION:
+            newProps.ephemeral = true;
+            newProps.key = `${_uniqPushed++}$${newProps.key}`;
             el.children.push(getInitialState(newProps, newState.scenes, el.children.length, action));
             el.index = el.children.length - 1;
             newState.scenes.current = getCurrent(newState).key;

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -102,6 +102,7 @@ function update(state,action){
             el.index = el.children.length - 1;
             newState.scenes.current = getCurrent(newState).key;
             if (newProps.ephemeral) {
+                assert(!newState.scenes.hasOwnProperty(newState.scenes.current), "scenes should not contain ephemeral key="+newState.scenes.current);
                 newState.scenes[newState.scenes.current] = newProps;
             }
             return newState;

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -83,7 +83,20 @@ function update(state,action){
 
         case REFRESH_ACTION:
             let ind = -1;
-            el.children.forEach((c,i)=>{if (c.key==action.key){ind=i}});
+            for (let i=0; i < el.children.length; i++) {
+                let c = el.children[i];
+                if (c.ephemeral) {
+                    if (c.key === action.key) {
+                        ind = i;
+                        break;
+                    }
+                } else {
+                    if (c.sceneKey === action.key) {
+                        ind = i;
+                        break;
+                    }
+                }
+            }
             assert(ind!=-1, "Cannot find route with key="+action.key+" for parent="+el.key);
             el.children[ind] = getInitialState(newProps, newState.scenes, ind, action);
             return newState;


### PR DESCRIPTION
first finds the current scene's parent and sets it as the parent of the new scene.  Scenes defined at the root level can be pushed into tab scenes.
- pushed scenes are added to the root state and removed on pop
- break early in findElement
- change getCurrent to return entire scene

*This solves my current use case, but please check your use cases to make sure I haven't altered other expectations of the library.*