### PR TITLE
use key from state.key to avoid losing the index_ prefix during refresh

### DIFF
--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -34,6 +34,8 @@ function inject(state, action, props, scenes) {
             case POP_ACTION:
                 return {...state, index:state.index-1, children:state.children.slice(0, -1) };
             case REFRESH_ACTION:
+                // use key from state.key to avoid losing the index_ prefix during refresh
+                props.key = state.key;
                 return {...state, ...props};
             case PUSH_ACTION:
                 if (state.children[state.index].sceneKey == action.key){


### PR DESCRIPTION
I *think* this fixes a bug, but would like someone to confirm.  I ran into this by doing:

```
  componentDidMount() {
    console.log('component mounting');
    Actions.refresh({
      key: this.props.navigationState.sceneKey,
      ...stuff
    });
  }
```

I noticed 'component mounting' printing twice and further inspected the navigationState.  The original key 1_foo was getting replaced with the sceneKey (foo).  With this adjustment, things seem to work correctly without the double component instantiation.

Although, it does read a little odd to call refresh with `key: sceneKey`.  Its possible I'm calling this wrong in the first place, but `key: key` doesn't seem to do the right thing with refresh.  Thoughts?