### PR TITLE
Feature/override images

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ class App extends React.Component {
 | titleStyle | Text style |  | optional style override for the title element |
 | leftTitle | string | | optional string to display on the left if the previous route does not provide `renderBackButton` prop. `renderBackButton` > `leftTitle` > <previous route's `title`> |
 | renderLeftButton | Closure | | optional closure to render the left title / buttons element |
+| drawerImage | Image | `'./menu_burger.png'` | Simple way to override the drawerImage in the navBar |
+| backButtonImage | Image | `'./back_chevron.png'` | Simple way to override the back button in the navBar |
 | renderBackButton | Closure | | optional closure to render back text or button if this route happens to be the previous route |
 | leftButtonStyle | View style | | optional style override for the container of left title / buttons |
 | leftButtonTextStyle | Text style | | optional style override for the left title element |

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -89,7 +89,7 @@ export default class NavBar extends React.Component {
               var drawer = this.context.drawer;
               drawer.toggle();
             }}>
-                <Image source={backButtonImage)} style={[styles.backButtonImage, this.props.navigationState.barButtonIconStyle]}/>
+                <Image source={backButtonImage} style={[styles.backButtonImage, this.props.navigationState.barButtonIconStyle]}/>
             </TouchableOpacity>
           );
         }else{

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -77,25 +77,33 @@ export default class NavBar extends React.Component {
     }
 
     _renderBackButton() {
-        if (this.props.navigationState.index === 0) {
-          if(!!this.context.drawer && typeof this.context.drawer.toggle === 'function'){
-            return (
-              <TouchableOpacity style={[styles.backButton, this.props.navigationState.leftButtonStyle]} onPress={() => {
-                var drawer = this.context.drawer;
-                drawer.toggle();
-              }}>
-                  <Image source={require('./menu_burger.png')} style={[styles.backButtonImage, this.props.navigationState.barButtonIconStyle]}/>
-              </TouchableOpacity>
-            );
-          }else{
-            return null;
-          }
-        }
-        return (
-            <TouchableOpacity style={[styles.backButton, this.props.navigationState.leftButtonStyle]} onPress={Actions.pop}>
-                <Image source={require('./back_chevron.png')} style={[styles.backButtonImage, this.props.navigationState.barButtonIconStyle]}/>
+      let backButtonImage;
+
+      if (this.props.navigationState.index === 0) {
+        if(!!this.context.drawer && typeof this.context.drawer.toggle === 'function'){
+
+          backButtonImage = this.props.navigationState.drawerImage || require('./menu_burger.png');
+
+          return (
+            <TouchableOpacity style={[styles.backButton, this.props.navigationState.leftButtonStyle]} onPress={() => {
+              var drawer = this.context.drawer;
+              drawer.toggle();
+            }}>
+                <Image source={backButtonImage)} style={[styles.backButtonImage, this.props.navigationState.barButtonIconStyle]}/>
             </TouchableOpacity>
-        );
+          );
+        }else{
+          return null;
+        }
+      }
+
+      backButtonImage = this.props.navigationState.backButtonImage || require('./back_chevron.png');
+
+      return (
+          <TouchableOpacity style={[styles.backButton, this.props.navigationState.leftButtonStyle]} onPress={Actions.pop}>
+              <Image source={backButtonImage} style={[styles.backButtonImage, this.props.navigationState.barButtonIconStyle]}/>
+          </TouchableOpacity>
+      );
     }
 
     _renderRightButton() {


### PR DESCRIPTION
Implemented a way to override the default images. I've tested this in my app and it works.

The reason for this PR, is because it's quite a lot of work atm to just override the image (you have to render the entire thing). This way, you can just do: 

```jsx
<Scene key="root" backButtonImage={require('image!back_chevron')}>
```