### PR TITLE
added possibility to use zero duration while navigating

### DIFF
--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -43,14 +43,19 @@ export default class DefaultRenderer extends Component {
         const selected = navigationState.children[navigationState.index];
         //return <DefaultRenderer key={selected.key} navigationState={selected}/>
 
+        const DEFAULT_DURATION = 250;
+        const stateDuration = navigationState.duration >= 0 ? navigationState.duration : DEFAULT_DURATION;
+        const duration = selected.duration >= 0 ? selected.duration : stateDuration;
+
         return (
             <NavigationAnimatedView
                 navigationState={navigationState}
                 style={[styles.animatedView, navigationState.style]}
                 renderOverlay={this._renderHeader}
                 direction={navigationState.direction || 'horizontal'}
-                setTiming={(pos, navState) => {
-          Animated.timing(pos, {toValue: navState.index, duration: navState.duration || navigationState.duration || selected.duration || 250}).start();}}
+                setTiming={(pos, navState) =>
+                    Animated.timing(pos, {toValue: navState.index, duration}).start()
+                }
                 renderScene={this._renderCard}
             />
         );


### PR DESCRIPTION
Added possibility to use zero duration while navigating
Before instead of zero was used default (250) value

Also as I understand in this case navState.duration and navigationState.duration - are always the same values

P.S. As for me it's better to check firstly _selected_ property as more specific, and then more general _navigationState_ property. Because otherwise you can not override it in children