### PR TITLE
Properly replace entire history stack - Fix for Issue #408

### DIFF
--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -52,7 +52,8 @@ function inject(state, action, props, scenes) {
                 if (state.children[state.index].sceneKey == action.key){
                     return state;
                 }
-                return {...state, children:[...state.children.slice(0,-1), getInitialState(props, scenes, state.index, action)]};
+                // return {...state, children:[...state.children.slice(0,-1), getInitialState(props, scenes, state.index, action)]};
+                return {...state, index:0, children:[getInitialState(props, scenes, state.index, action)]};
             default:
                 return state;
 


### PR DESCRIPTION
Current `type='replace'` allows going "back" through history still.

This replaces entire history stack.

https://github.com/aksonov/react-native-router-flux/issues/408