### PR TITLE
Check properties sended in route are equal to prevent pushing new routes

### DIFF
--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -12,6 +12,20 @@ import assert from 'assert';
 import Immutable from 'immutable';
 import {getInitialState} from './State';
 
+const checkPropertiesEqual = (action, lastAction) => {
+  let isEqual = true;
+  for(let i in action) {
+    if(action.hasOwnProperty(i) && ['key', 'type', 'parent'].indexOf(i) == -1) {//property is passed as argument
+      if(action[i] != lastAction[i]) {
+        isEqual = false;
+      }
+    }
+  }
+
+  return isEqual;
+
+}
+
 function inject(state, action, props, scenes) {
     const condition = action.type == REFRESH_ACTION ? state.key === props.key || state.sceneKey === action.key : state.sceneKey == props.parent;
     if (!condition){
@@ -37,7 +51,7 @@ function inject(state, action, props, scenes) {
             case REFRESH_ACTION:
                 return {...state, ...props};
             case PUSH_ACTION:
-                if (state.children[state.index].sceneKey == action.key && !props.clone){
+                if (state.children[state.index].sceneKey == action.key && !props.clone && checkPropertiesEqual(action, state.children[state.index])){
                     return state;
                 }
                 return {...state, index:state.index+1, children:[...state.children, getInitialState(props, scenes, state.index + 1, action)]};


### PR DESCRIPTION
Hi,

This PR checks that parameters are equal to prevent pushing new routes.

Example :

```javascript
Actions.menu({
    category: 1
});
setTimeout(()=>{ 
  Actions.menu({
    category: 2
  });
});
```

Now pushes the routes.

NOTE :

```javascript
Actions.menu({
    category: { foo: 'bar' }
});
setTimeout(()=>{ 
  Actions.menu({
    category: { foo: 'bar' }
  });
});
```
Also pushes the two routes, as my test case is '==' .

I can add a deep equals if needed.

Please tell me if you need anything else.