### PR TITLE
hideNavBar hide scene only for current scene

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -63,7 +63,7 @@ export default class NavBar extends React.Component {
         if (selected.component && selected.component.renderNavigationBar){
             return selected.component.renderNavigationBar({...this.props,...selected});
         }
-        if (state.hideNavBar || child.hideNavBar || selected.hideNavBar){
+        if (child.hideNavBar || selected.hideNavBar){
             return null;
         }
         return (


### PR DESCRIPTION
As written in docs, hideNavBar "hides navigation bar for this scene", but previously it can hided it for children too.

As I understand - it's more correct and behaviour.
For example if we want to show beautiful flowFromBottom animation (when title animates with page) - that should work:
```
<Scene key="newPage" direction="vertical" hideNavBar={true}>
   <Scene key="newPageView"
	   title="New "
	   component={Page}
	   leftTitle="Cancel"
	   onLeft={props => Actions.pop()}
	   rightTitle="Done"
	   onRight={props => makeDone(props.id)}
    />			
</Scene>
```