### PR TITLE
Added popToTop functionality

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -13,6 +13,7 @@ export const PUSH_ACTION = "push";
 export const REPLACE_ACTION = "replace";
 export const POP_ACTION2 = "back";
 export const POP_ACTION = "BackAction";
+export const POP_TO_TOP = 'popToTop';
 export const REFRESH_ACTION = "refresh";
 export const RESET_ACTION = "reset";
 export const INIT_ACTION = "init";

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {PUSH_ACTION, POP_ACTION2, FOCUS_ACTION, JUMP_ACTION, INIT_ACTION, REPLACE_ACTION, RESET_ACTION, POP_ACTION, REFRESH_ACTION} from "./Actions";
+import {PUSH_ACTION, POP_ACTION2, POP_TO_TOP, FOCUS_ACTION, JUMP_ACTION, INIT_ACTION, REPLACE_ACTION, RESET_ACTION, POP_ACTION, REFRESH_ACTION} from "./Actions";
 import assert from "assert";
 import Immutable from "immutable";
 import {getInitialState} from "./State";
@@ -48,6 +48,11 @@ function inject(state, action, props, scenes) {
             case POP_ACTION:
                 assert(!state.tabs, "pop() operation cannot be run on tab bar (tabs=true)")
                 return {...state, index:state.index-1, children:state.children.slice(0, -1) };
+            case POP_TO_TOP:
+                assert(state.tabs, "Parent="+state.key+" is not tab bar, popToTop action is not valid");
+                let child = state.children[state.index];
+                let newChild = {...child, ...{children: [child.children[0]], index:0}};
+                return {...state, ...{children:[...state.children.slice(0,state.index), newChild, ...state.children.slice(state.index+1)]}};
             case REFRESH_ACTION:
                 return {...state, ...props};
             case PUSH_ACTION:
@@ -152,6 +157,7 @@ function reducer({initialState, scenes}){
         switch (action.type) {
             case POP_ACTION2:
             case POP_ACTION:
+            case POP_TO_TOP:
             case REFRESH_ACTION:
             case PUSH_ACTION:
             case JUMP_ACTION:


### PR DESCRIPTION
Hi,

In my app there are a few tabs, and the state is persisted if you toggle between them (thanks to PR #390). If you are already inside the tab however, I would like the state to be reset to the base of the tab for easy navigation. 

I've added an action called popToTop (name based on https://facebook.github.io/react-native/docs/navigator.html#content). 

I can now do this in my reducer:
```js
const reducerCreate = params=> {
  const defaultReducer = Reducer(params);
  return (state, action)=>{
    if (state) {
      let currentTabIndex = state.children[0].index;
      if (state.children[0].children[currentTabIndex].name === action.key && action.type === 'jump') {
        return defaultReducer(state, {...action, ...{type:'popToTop'}});
      }
    }
    return defaultReducer(state, action);
  }
};
```

I figured I'd do a pull to see if you'd like to add it to the repo. I couldnt find where in the docs it would be added but if you can point me to it I can add it there too.

Regards