### PR TITLE
Make `sceneStyle` work without having to apply styles manually

### DIFF
--- a/Example/Example.js
+++ b/Example/Example.js
@@ -47,14 +47,14 @@ const reducerCreate = params=>{
 
 export default class Example extends React.Component {
     render() {
-        return <Router createReducer={reducerCreate} sceneStyle={{backgroundColor:'#F7F7F7'}}>
+        return <Router createReducer={reducerCreate}>
             <Scene key="modal" component={Modal} >
                 <Scene key="root" hideNavBar={true}>
                     <Scene key="echo" clone component={EchoView} />
                     <Scene key="register" component={Register} title="Register"/>
                     <Scene key="register2" component={Register} title="Register2" duration={1}/>
                     <Scene key="home" component={Home} title="Replace" type="replace"/>
-                    <Scene key="launch" component={Launch} title="Launch" initial={true} style={{flex:1, backgroundColor:"transparent"}}/>
+                    <Scene key="launch" component={Launch} title="Launch" initial={true} />
                     <Scene key="login" direction="vertical"  >
                         <Scene key="loginModal" component={Login} title="Login"/>
                         <Scene key="loginModal2" hideNavBar={true} component={Login2} title="Login2" panHandlers={null} duration={1}/>

--- a/Example/components/Launch.js
+++ b/Example/components/Launch.js
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
 class Launch extends React.Component {
     render(){
         return (
-            <View {...this.props}  style={[styles.container, this.props.sceneStyle]}>
+            <View {...this.props}  style={styles.container}>
                 <Text>Launch page</Text>
                 <Button onPress={()=>Actions.login({data:"Custom data", title:"Custom title" })}>Go to Login page</Button>
                 <Button onPress={Actions.register}>Go to Register page</Button>

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ class App extends React.Component {
 | rightButtonTextStyle | Text style | | optional style override for the right title element |
 | clone | bool | | Scenes marked with `clone` will be treated as templates and cloned into the current scene's parent when pushed. See example. |
 | tabBarStyle | View style |  | optional style override for the Tabs component |
+| sceneStyle | View style | { flex: 1 } | optional style override for the Scene's component |
 | other props | | | all properties that will be passed to your component instance |
 
 ## Example

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React, {Component, Animated, StyleSheet, ScrollView, Text, NavigationExperimental} from "react-native";
+import React, {Component, Animated, StyleSheet, ScrollView, View, Text, NavigationExperimental} from "react-native";
 const {
     AnimatedView: NavigationAnimatedView,
     Card: NavigationCard,
@@ -37,7 +37,11 @@ export default class DefaultRenderer extends Component {
             Component = TabBar;
         }
         if (Component) {
-            return <Component style={navigationState.sceneStyle} {...navigationState} navigationState={navigationState} />
+            return (
+                <View style={[{flex: 1}, navigationState.sceneStyle]}>
+                    <Component {...navigationState} navigationState={navigationState} />
+                </View>
+            )
         }
 
         const selected = navigationState.children[navigationState.index];


### PR DESCRIPTION
This PR wraps each Scene component in a view so that `sceneStyle`s can be applied without the developer having to set them manually.

This idea was discussed in https://github.com/aksonov/react-native-router-flux/commit/c42b48b1e04bec828b11a6417708320f150493dc

`sceneStyle` will not have any effect on Scenes that do not specify a component.

Example code is tidied up to avoid confusion.

Related: #452 