### PR TITLE
Removed transparent background to remove warning #448

### DIFF
--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -80,7 +80,6 @@ export default class DefaultRenderer extends Component {
                 direction={props.scene.navigationState.direction || "horizontal"}
                 panHandlers={props.scene.navigationState.panHandlers }
                 renderScene={this._renderScene}
-                style={{backgroundColor:"transparent"}}
             />
         );
     }


### PR DESCRIPTION
Removing the transparent background color I don't get this warning anymore [#448](https://github.com/aksonov/react-native-router-flux/issues/448) and I can still set a global background color by creating a dedicated container, that I usually use in all my top level components.