### PR TITLE
Add `from` prop to navigation state for better pop animations

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  presets: ["react-native"]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 Example/
 .idea
-
+.babelrc

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "mocha --compilers js:babel-core/register --require react-native-mock/mock",
+    "test:watch": "npm run test -- --watch"
   },
   "keywords": [
     "react-native",
@@ -43,6 +44,7 @@
     "babel-core": "^6.7.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-react-native": "^1.5.6",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -47,14 +47,28 @@ function inject(state, action, props, scenes) {
             case POP_ACTION2:
             case POP_ACTION:
                 assert(!state.tabs, "pop() operation cannot be run on tab bar (tabs=true)")
-                return {...state, index:state.index-1, children:state.children.slice(0, -1) };
+                return {
+                    ...state,
+                    index:state.index-1,
+                    from: state.children[state.children.length - 1],
+                    children:state.children.slice(0, -1),
+                };
             case REFRESH_ACTION:
-                return {...state, ...props};
+                return {
+                    ...state,
+                    ...props,
+                    from: null
+                };
             case PUSH_ACTION:
                 if (state.children[state.index].sceneKey == action.key && !props.clone && checkPropertiesEqual(action, state.children[state.index])){
                     return state;
                 }
-                return {...state, index:state.index+1, children:[...state.children, getInitialState(props, scenes, state.index + 1, action)]};
+                return {
+                    ...state,
+                    index:state.index+1,
+                    from: null,
+                    children:[...state.children, getInitialState(props, scenes, state.index + 1, action)]
+                };
             case JUMP_ACTION:
                 assert(state.tabs, "Parent="+state.key+" is not tab bar, jump action is not valid");
                 let ind = -1;

--- a/test/Actions.test.js
+++ b/test/Actions.test.js
@@ -56,15 +56,15 @@ describe('Actions', () => {
         Actions.callback = scene=>state = reducer(state, scene);
         expect(state).equal(undefined);
         Actions.init();
-        expect(state.key).equal("modal");
+        expect(state.key).equal("0_modal");
 
         Actions.messaging();
-        expect(state.scenes.current).equal("messaging");
+        expect(currentScene.key).equal("messaging");
         //Actions.pop();
         Actions.login();
-        expect(state.children[1].key).equal("login");
+        expect(state.children[1].key).equal("1_login");
         expect(state.children[1].children.length).equal(1);
-        expect(state.children[1].children[0].key).equal("loginModal1");
+        expect(state.children[1].children[0].key).equal("0_loginModal1");
 
     });
 

--- a/test/Actions.test.js
+++ b/test/Actions.test.js
@@ -60,11 +60,14 @@ describe('Actions', () => {
 
         Actions.messaging();
         expect(currentScene.key).equal("messaging");
-        //Actions.pop();
+
         Actions.login();
         expect(state.children[1].key).equal("1_login");
         expect(state.children[1].children.length).equal(1);
         expect(state.children[1].children[0].key).equal("0_loginModal1");
+
+        Actions.pop();
+        expect(state.from.key).equal("1_login");
 
     });
 


### PR DESCRIPTION
This PR introduces a new navigation state prop, `from`, which is the scene that was just popped from the animation stack. This allows for smoother pop animations when you need to transition stuff out of the scene.

Some gifs below demonstrate the issue (notice the ability for the RHS text to animate out):

Without `from`, the "change" text disappears right away when popping:
![](http://i.giphy.com/xT1XGYVwLHxnmaAHug.gif)

With `from`, the "change" text animates out:
![](http://i.giphy.com/xT1XGzVizubq3XxlGU.gif)

Note: this PR is checked out on top of #504 which makes the tests work.