### PR TITLE
Provide navigationState to scene's context

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  presets: ["react-native"]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 Example/
 .idea
-
+.babelrc

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "mocha --compilers js:babel-core/register --require react-native-mock/mock",
+    "test:watch": "npm run test -- --watch"
   },
   "keywords": [
     "react-native",
@@ -43,6 +44,7 @@
     "babel-core": "^6.7.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-react-native": "^1.5.6",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -27,6 +27,12 @@ export default class DefaultRenderer extends Component {
         this._renderHeader = this._renderHeader.bind(this);
     }
 
+    getChildContext() {
+        return {
+            navigationState: this.props.navigationState,
+        };
+    }
+
     render() {
         const navigationState = this.props.navigationState;
         if (!navigationState) {
@@ -101,6 +107,10 @@ export default class DefaultRenderer extends Component {
     }
 
 }
+
+DefaultRenderer.childContextTypes = {
+    navigationState: PropTypes.any,
+};
 
 const styles = StyleSheet.create({
     animatedView: {

--- a/test/Actions.test.js
+++ b/test/Actions.test.js
@@ -56,15 +56,15 @@ describe('Actions', () => {
         Actions.callback = scene=>state = reducer(state, scene);
         expect(state).equal(undefined);
         Actions.init();
-        expect(state.key).equal("modal");
+        expect(state.key).equal("0_modal");
 
         Actions.messaging();
-        expect(state.scenes.current).equal("messaging");
+        expect(currentScene.key).equal("messaging");
         //Actions.pop();
         Actions.login();
-        expect(state.children[1].key).equal("login");
+        expect(state.children[1].key).equal("1_login");
         expect(state.children[1].children.length).equal(1);
-        expect(state.children[1].children[0].key).equal("loginModal1");
+        expect(state.children[1].children[0].key).equal("0_loginModal1");
 
     });
 


### PR DESCRIPTION
This PR makes it so that `DefaultRenderer` passes in `navigationState` as context to the rendered scene. I have found this useful for a number of things (most notably, tracking a shared `scroll` animated value that the navigation bar is aware of and uses to animate things, such as opacity.

I believe this to be a valid use case for `context`. Would be much appreciated if we could get this merged in.

Thanks! Let me know if you have any questions.

(Note this is also based off of #504 )