### PR TITLE
Add getSceneStyle api to Scene and Router

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  presets: ["react-native"]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 Example/
 .idea
-
+.babelrc

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ class App extends React.Component {
 | other props | | | all properties that will be passed to all your scenes |
 | children | | required (if no scenes property passed)| Scene root element |
 | scenes | object | optional | scenes for Router created with Actions.create. This will allow to create all actions BEFORE React processing. If you don't need it you may pass Scene root element as children |
+| getSceneStyle | function | optional | Optionally override the styles for NavigationCard's Animated.View rendering the scene. |
 ##### Scene:
 
 | Property | Type | Default | Description |
@@ -130,6 +131,7 @@ class App extends React.Component {
 | tabBarStyle | View style |  | optional style override for the Tabs component |
 | sceneStyle | View style | { flex: 1 } | optional style override for the Scene's component |
 | other props | | | all properties that will be passed to your component instance |
+| getSceneStyle | function | optional | Optionally override the styles for NavigationCard's Animated.View rendering the scene. |
 
 ## Example
 ![launch](https://cloud.githubusercontent.com/assets/1321329/11692367/7337cfe2-9e9f-11e5-8515-e8b7a9f230ec.gif)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "mocha --compilers js:babel-core/register --require react-native-mock/mock",
+    "test:watch": "npm run test -- --watch"
   },
   "keywords": [
     "react-native",
@@ -43,6 +44,7 @@
     "babel-core": "^6.7.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-react-native": "^1.5.6",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -84,14 +84,16 @@ export default class DefaultRenderer extends Component {
     }
 
     _renderCard(/*NavigationSceneRendererProps*/ props) {
+        const { key, direction, panHandlers, getSceneStyle } = props.scene.navigationState;
+        const style = getSceneStyle ? getSceneStyle(props) : null;
         return (
             <NavigationCard
                 {...props}
-                style={props.scene.navigationState.style}
-                key={"card_" + props.scene.navigationState.key}
-                direction={props.scene.navigationState.direction || "horizontal"}
-                panHandlers={props.scene.navigationState.panHandlers }
+                key={'card_' + key}
+                direction={direction || 'horizontal'}
+                panHandlers={panHandlers}
                 renderScene={this._renderScene}
+                style={style}
             />
         );
     }

--- a/test/Actions.test.js
+++ b/test/Actions.test.js
@@ -56,15 +56,15 @@ describe('Actions', () => {
         Actions.callback = scene=>state = reducer(state, scene);
         expect(state).equal(undefined);
         Actions.init();
-        expect(state.key).equal("modal");
+        expect(state.key).equal("0_modal");
 
         Actions.messaging();
-        expect(state.scenes.current).equal("messaging");
+        expect(currentScene.key).equal("messaging");
         //Actions.pop();
         Actions.login();
-        expect(state.children[1].key).equal("login");
+        expect(state.children[1].key).equal("1_login");
         expect(state.children[1].children.length).equal(1);
-        expect(state.children[1].children[0].key).equal("loginModal1");
+        expect(state.children[1].children[0].key).equal("0_loginModal1");
 
     });
 


### PR DESCRIPTION
This PR adds a `getSceneStyle` prop that you can pass to `<Scene />` and `<Router />` and it will be passed into the `style` prop of the `<NavigationCard />` in react native. This allows the user to customize the transition animations without reimplementing all of this library.

Let me know if you have any questions!

Like the other PRs, this is based on top of #504.