### PR TITLE
Add getInitialState API to Scene and Router

### DIFF
--- a/src/State.js
+++ b/src/State.js
@@ -8,10 +8,34 @@
  */
 import assert from "assert";
 
+function getStateFromScenes(route, scenes, props) {
+    const getters = [];
+    let result = {};
+    let scene = route;
+    while (scene) {
+        if (scene.getInitialState) {
+            getters.push(scene.getInitialState);
+        }
+        scene = scenes[scene.parent];
+    }
+
+    getters.reverse().forEach(fn => {
+        result = {...result, ...fn(props)};
+    });
+
+    return result;
+}
+
 export function getInitialState(route:{string: any},scenes:{string:any}, position=0, props={}){
     const {key, style, type, ...parentProps} = props;
     if (!route.children){
-        return { ...scenes.rootProps, ...route, key:position+"_"+route.sceneKey, ...parentProps,};
+        return {
+            ...scenes.rootProps,
+            ...route,
+            key:position+"_"+route.sceneKey,
+            ...parentProps,
+            ...getStateFromScenes(route, scenes, props),
+        };
     }
     let {children, ...res} = {...route, ...parentProps};
     let index = 0;

--- a/test/Actions.test.js
+++ b/test/Actions.test.js
@@ -5,30 +5,32 @@ import React from 'react-native';
 import Scene from '../src/Scene';
 import createReducer from '../src/Reducer';
 
-const scenesData = <Scene component="Modal" key="modal">
-    <Scene key="launch" component="Launch"/>
-    <Scene key="sideMenu" component="Drawer" initial={true}>
-        <Scene component="CubeBar" key="cubeBar" type="tabs">
-            <Scene key="main" tabs={true}>
-                <Scene key="home" component="Home"/>
-                <Scene key="map" component="Map"/>
-                <Scene key="myAccount" component="MyAccount"/>
-            </Scene>
-            <Scene key="messaging" initial={true}>
-                <Scene key="conversations" component="Conversations"/>
-            </Scene>
-        </Scene>
-    </Scene>
-    <Scene key="privacyPolicy" component="PrivacyPolicy" type="modal"/>
-    <Scene key="termsOfService" component="TermsOfService" type="modal"/>
-    <Scene key="login">
-        <Scene key="loginModal1" component="Login1"/>
-        <Scene key="loginModal2" component="Login2"/>
-    </Scene>
-</Scene>;
-
 describe('Actions', () => {
     it('should create needed actions', () => {
+        let id = 0;
+        const guid = () => id++;
+
+        const scenesData = <Scene component="Modal" key="modal" getInitialState={() => ({ foo: guid() })}>
+            <Scene key="launch" component="Launch"/>
+            <Scene key="sideMenu" component="Drawer" initial={true}>
+                <Scene component="CubeBar" key="cubeBar" type="tabs">
+                    <Scene key="main" tabs={true}>
+                        <Scene key="home" component="Home"/>
+                        <Scene key="map" component="Map"/>
+                        <Scene key="myAccount" component="MyAccount"/>
+                    </Scene>
+                    <Scene key="messaging" initial={true}>
+                        <Scene key="conversations" component="Conversations" getInitialState={() => ({ foo: 'what', bar: guid() })}/>
+                    </Scene>
+                </Scene>
+            </Scene>
+            <Scene key="privacyPolicy" component="PrivacyPolicy" type="modal"/>
+            <Scene key="termsOfService" component="TermsOfService" type="modal"/>
+            <Scene key="login">
+                <Scene key="loginModal1" component="Login1"/>
+                <Scene key="loginModal2" component="Login2"/>
+            </Scene>
+        </Scene>;
         const scenes = Actions.create(scenesData);
         expect(scenes.conversations.component).to.equal("Conversations");
 
@@ -57,6 +59,8 @@ describe('Actions', () => {
         expect(state).equal(undefined);
         Actions.init();
         expect(state.key).equal("0_modal");
+        expect(state.children[0].children[0].children[0].children[0].bar).equal(1);
+        expect(state.children[0].children[0].children[0].children[0].foo).equal('what');
 
         Actions.messaging();
         expect(currentScene.key).equal("messaging");
@@ -69,6 +73,9 @@ describe('Actions', () => {
         Actions.pop();
         expect(state.from.key).equal("1_login");
 
+        Actions.launch();
+        expect(state.children[1].foo).equal(3);
+        expect(state.children[1].bar).equal(undefined);
     });
 
 });


### PR DESCRIPTION
This PR adds a `getInitialState` prop that can be passed into the `<Scene />` or `<Router />` components  which will be run each time an instance of the scene is added to the stack. This is a use case not supported by the current props being added to the navigation state, which will only allow for static constants being passed to the scene. With `getInitialState`, you can create state that persists for the entirety of the scene, but is unique across instances of the same scene. This is useful for a variety of cases.

The API is done in such a way that you can define a `getInitialState` function for a parent scene and it will get passed to a child scene, but it will be merged in with the `getInitialState` calls of the children scenes.