### PR TITLE
Allow getInitialState to be passed into Router as well as Scene

### DIFF
--- a/src/State.js
+++ b/src/State.js
@@ -19,6 +19,10 @@ function getStateFromScenes(route, scenes, props) {
         scene = scenes[scene.parent];
     }
 
+    if (scenes.rootProps && scenes.rootProps.getInitialState) {
+        getters.push(scenes.rootProps.getInitialState);
+    }
+
     getters.reverse().forEach(fn => {
         result = {...result, ...fn(props)};
     });


### PR DESCRIPTION
This was a missing piece of #509 that allows a `getInitialState` function to be supplied to Router, which will then be applied to every child scene under it.

Let me know if there are any questions!