### PR TITLE
Bug fix: childContextTypes not defined when DefaultRenderer is exported

### DIFF
--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -27,6 +27,10 @@ export default class DefaultRenderer extends Component {
         this._renderHeader = this._renderHeader.bind(this);
     }
 
+    static childContextTypes = {
+        navigationState: PropTypes.any,
+    };
+
     getChildContext() {
         return {
             navigationState: this.props.navigationState,
@@ -110,14 +114,9 @@ export default class DefaultRenderer extends Component {
 
 }
 
-DefaultRenderer.childContextTypes = {
-    navigationState: PropTypes.any,
-};
-
 const styles = StyleSheet.create({
     animatedView: {
         flex: 1,
         backgroundColor:"transparent"
     },
 });
-


### PR DESCRIPTION
Currently getting this error with 3.2.12 & RN 0.23.1:

```
DefaultRenderer.getChildContext(): childContextTypes must be defined in order to use getChildContext().
```

This PR fixes that issue. Thanks for the great module!