### PR TITLE
Fix animation bug

### DIFF
--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -95,7 +95,10 @@ export default class DefaultRenderer extends Component {
 
     _renderCard(/*NavigationSceneRendererProps*/ props) {
         const { key, direction, panHandlers, getSceneStyle } = props.scene.navigationState;
-        const style = getSceneStyle ? getSceneStyle(props) : null;
+
+        const optionals = {};
+        if (getSceneStyle) optionals.style = getSceneStyle(props);
+
         return (
             <NavigationCard
                 {...props}
@@ -103,7 +106,7 @@ export default class DefaultRenderer extends Component {
                 direction={direction || 'horizontal'}
                 panHandlers={panHandlers}
                 renderScene={this._renderScene}
-                style={style}
+                {...optionals}
             />
         );
     }


### PR DESCRIPTION
Changes the `NavigationCard`'s `style` prop to be truly optional.

`NavigationCard` does a strict comparison (`this.props.style === undefined`) to fallback to the default style. Because `style` was defaulting to `null`, the comparison failed.