### PR TITLE
Add FOCUS action, dispatch when react-redux is available

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -44,7 +44,7 @@ class Actions {
         this.init = this.init.bind(this);
         this.pop = this.pop.bind(this);
         this.refresh = this.refresh.bind(this);
-
+        this.FOCUS_ACTION = FOCUS_ACTION;
     }
 
     iterate(root: Scene, parentProps = {}, refs = {}) {
@@ -111,6 +111,10 @@ class Actions {
         let refs = {};
         this.iterate(scene, {}, refs);
         return refs
+    }
+
+    focus(scene){
+        return {type: FOCUS_ACTION, scene};
     }
 }
 

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -18,15 +18,18 @@ import getInitialState from "./State";
 import Reducer from "./Reducer";
 import TabBar from "./TabBar";
 import NavBar from "./NavBar";
-import {connect} from "react-redux";
 
-class DefaultRenderer extends Component {
+export default class DefaultRenderer extends Component {
     constructor(props) {
         super(props);
         this._renderCard = this._renderCard.bind(this);
         this._renderScene = this._renderScene.bind(this);
         this._renderHeader = this._renderHeader.bind(this);
     }
+
+    static contextTypes = {
+        dispatch: PropTypes.func,
+    };
 
     static childContextTypes = {
         navigationState: PropTypes.any,
@@ -47,11 +50,11 @@ class DefaultRenderer extends Component {
     }
 
     dispatchFocusAction({navigationState}) {
-      if (!this.props.dispatch || !navigationState || navigationState.component || navigationState.tabs) {
+      if (!this.context.dispatch || !navigationState || navigationState.component || navigationState.tabs) {
         return;
       }
       const selected = navigationState.children[navigationState.index];
-      this.props.dispatch(Actions.focus(selected));
+      this.context.dispatch(Actions.focus(selected));
     }
 
     render() {
@@ -140,5 +143,3 @@ const styles = StyleSheet.create({
         backgroundColor:"transparent"
     },
 });
-
-export default (connect) ? connect()(DefaultRenderer) : DefaultRenderer;

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -38,6 +38,22 @@ class DefaultRenderer extends Component {
         };
     }
 
+    componentDidMount() {
+      this.dispatchFocusAction(this.props);
+    }
+
+    componentWillReceiveProps(nextProps) {
+      this.dispatchFocusAction(nextProps);
+    }
+
+    dispatchFocusAction({navigationState}) {
+      if (!this.props.dispatch || !navigationState || navigationState.component || navigationState.tabs) {
+        return;
+      }
+      const selected = navigationState.children[navigationState.index];
+      this.props.dispatch(Actions.focus(selected));
+    }
+
     render() {
         const navigationState = this.props.navigationState;
         if (!navigationState) {
@@ -61,10 +77,6 @@ class DefaultRenderer extends Component {
         let applyAnimation = selected.applyAnimation || navigationState.applyAnimation;
         let style = selected.style || navigationState.style;
         let direction = selected.direction || navigationState.direction || "horizontal";
-
-        if (this.props.dispatch) {
-          this.props.dispatch(Actions.focus(selected));
-        }
 
         let optionals = {};
         if (applyAnimation) {

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -126,6 +126,4 @@ const styles = StyleSheet.create({
     },
 });
 
-const Output = (connect) ? connect()(DefaultRenderer) : DefaultRenderer;
-
-export default Output;
+export default (connect) ? connect()(DefaultRenderer) : DefaultRenderer;

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -18,8 +18,9 @@ import getInitialState from "./State";
 import Reducer from "./Reducer";
 import TabBar from "./TabBar";
 import NavBar from "./NavBar";
+import {connect} from "react-redux";
 
-export default class DefaultRenderer extends Component {
+class DefaultRenderer extends Component {
     constructor(props) {
         super(props);
         this._renderCard = this._renderCard.bind(this);
@@ -61,6 +62,10 @@ export default class DefaultRenderer extends Component {
         let style = selected.style || navigationState.style;
         let direction = selected.direction || navigationState.direction || "horizontal";
 
+        if (this.props.dispatch) {
+          this.props.dispatch(Actions.focus(selected));
+        }
+
         let optionals = {};
         if (applyAnimation) {
             optionals.applyAnimation = applyAnimation;
@@ -95,10 +100,7 @@ export default class DefaultRenderer extends Component {
 
     _renderCard(/*NavigationSceneRendererProps*/ props) {
         const { key, direction, panHandlers, getSceneStyle } = props.scene.navigationState;
-
-        const optionals = {};
-        if (getSceneStyle) optionals.style = getSceneStyle(props);
-
+        const style = getSceneStyle ? getSceneStyle(props) : null;
         return (
             <NavigationCard
                 {...props}
@@ -106,7 +108,7 @@ export default class DefaultRenderer extends Component {
                 direction={direction || 'horizontal'}
                 panHandlers={panHandlers}
                 renderScene={this._renderScene}
-                {...optionals}
+                style={style}
             />
         );
     }
@@ -123,3 +125,7 @@ const styles = StyleSheet.create({
         backgroundColor:"transparent"
     },
 });
+
+const Output = (connect) ? connect()(DefaultRenderer) : DefaultRenderer;
+
+export default Output;

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -112,7 +112,10 @@ class DefaultRenderer extends Component {
 
     _renderCard(/*NavigationSceneRendererProps*/ props) {
         const { key, direction, panHandlers, getSceneStyle } = props.scene.navigationState;
-        const style = getSceneStyle ? getSceneStyle(props) : null;
+
+        const optionals = {};
+        if (getSceneStyle) optionals.style = getSceneStyle(props);
+
         return (
             <NavigationCard
                 {...props}
@@ -120,7 +123,7 @@ class DefaultRenderer extends Component {
                 direction={direction || 'horizontal'}
                 panHandlers={panHandlers}
                 renderScene={this._renderScene}
-                style={style}
+                {...optionals}
             />
         );
     }

--- a/src/Router.js
+++ b/src/Router.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React, {Component, StyleSheet, ScrollView, Text, NavigationExperimental} from "react-native";
+import React, {PropTypes, Component, StyleSheet, ScrollView, Text, NavigationExperimental} from "react-native";
 const {
     AnimatedView: NavigationAnimatedView,
     Card: NavigationCard,
@@ -19,11 +19,21 @@ import Reducer from "./Reducer";
 import DefaultRenderer from "./DefaultRenderer";
 
 export default class extends Component {
+    static childContextTypes = {
+        dispatch: PropTypes.func,
+    };
+
     constructor(props) {
         super(props);
         this.state = {};
         this._renderNavigation = this._renderNavigation.bind(this);
         this._handleProps = this._handleProps.bind(this);
+    }
+
+    getChildContext() {
+        return {
+            dispatch: this.props.dispatch,
+        };
     }
 
     _handleProps(props){


### PR DESCRIPTION
### Problem:

My app needs to know which screen is currently in focus. Because the `*_FOCUS` actions were removed in v3, this is no longer possible.

### Solution:

Implement the `FOCUS_ACTION` action. Dispatch the event when redux-router is present. The action payload contains the props for the screen that is currently in focus (`name`, `title`, etc.).

Usage is as follows:

~~~js
// reducers/routes.js

import { createReducer } from 'redux-immutablejs';
import Immutable from 'immutable';
import {Actions} from 'react-native-router-flux';

const {FOCUS_ACTION} = Actions;

const initialState = Immutable.fromJS({
  scene: {},
});

export default createReducer(initialState, {
  [FOCUS_ACTION]: (state, {scene}) => state.merge({scene}),
});
~~~

##### EDIT:

Instead of importing `react-redux`, it's better to pass the `dispatch` method to the router. This frees RNRF from any dependencies.

So usage from the router should be as follows:

~~~js
// routes.js

import React, {PropTypes} from 'react';
import {
  Actions,
  Router,
  Scene,
} from 'react-native-router-flux';
import Dashboard from './scenes/Dashboard';

const scenes = Actions.create(
  <Scene key="Root">
    <Scene key="Main">
      <Scene
        key="Dashboard"
        title="Dashboard"
        component={Dashboard}/>
    </Scene>

    {/* ... more scenes */ }
  </Scene>
);

class Routes extends React.Component {
  static propTypes = {
    dispatch: PropTypes.func,
  };

  render () {
    return (
      <Router
        dispatch={this.props.dispatch} <-- pass the dispatch method to the router
        scenes={scenes} />
      );
  }
}

// make sure to "connect" the routes component
export default connect()(Routes);
~~~

That's it!