### PR TITLE
Set the example to use the supported version of React Native

### DIFF
--- a/Example/.babelrc
+++ b/Example/.babelrc
@@ -1,0 +1,3 @@
+{
+  presets: ["react-native"]
+}

--- a/Example/package.json
+++ b/Example/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "^0.14.7",
-    "react-native": "^0.23.1",
+    "react-native": "^0.22.2",
     "react-native-button": "^1.2.1",
     "react-native-drawer": "^1.16.7",
     "react-native-modalbox": "^1.3.0",


### PR DESCRIPTION
While 0.22.2 remains the supported version is doesn't seem to make sense to use 0.23.1 in the example app.