### PR TITLE
[WIP] Get Example app working with React 0.24+ 

### DIFF
--- a/Example/.buckconfig
+++ b/Example/.buckconfig
@@ -1,0 +1,6 @@
+
+[android]
+  target = Google Inc.:Google APIs:23
+
+[maven_repositories]
+  central = https://repo1.maven.org/maven2

--- a/Example/.flowconfig
+++ b/Example/.flowconfig
@@ -42,6 +42,12 @@
 # Ignore Website
 .*/website/.*
 
+# Ignore generators
+.*/local-cli/generator.*
+
+# Ignore BUCK generated folders
+.*\.buckd/
+
 .*/node_modules/is-my-json-valid/test/.*\.json
 .*/node_modules/iconv-lite/encodings/tables/.*\.json
 .*/node_modules/y18n/test/.*\.json
@@ -58,6 +64,7 @@
 .*/node_modules/joi/.*\.json
 .*/node_modules/isemail/.*\.json
 .*/node_modules/tr46/.*\.json
+
 
 [include]
 
@@ -86,4 +93,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-2]\\|1[0-9]\\|[0-9
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 [version]
-0.22.0
+^0.22.0

--- a/Example/.gitignore
+++ b/Example/.gitignore
@@ -32,3 +32,9 @@ local.properties
 #
 node_modules/
 npm-debug.log
+
+# BUCK
+buck-out/
+\.buckd/
+android/app/libs
+android/keystores/debug.keystore

--- a/Example/Example.js
+++ b/Example/Example.js
@@ -59,7 +59,7 @@ export default class Example extends React.Component {
                         <Scene key="loginModal" component={Login} title="Login"/>
                         <Scene key="loginModal2" hideNavBar={true} component={Login2} title="Login2" panHandlers={null} duration={1}/>
                     </Scene>
-                    <Scene key="tabbar" component={NavigationDrawer}>
+                    <Scene key="tabbar" component={NavigationDrawer} panHandlers={null}>
                         <Scene key="main" tabs={true} >
                             <Scene key="tab1"  title="Tab #1" icon={TabIcon} navigationBarStyle={{backgroundColor:"red"}} titleStyle={{color:"white"}}>
                                 <Scene key="tab1_1" component={TabView} title="Tab #1_1" onRight={()=>alert("Right button")} rightTitle="Right" />

--- a/Example/android/app/BUCK
+++ b/Example/android/app/BUCK
@@ -1,0 +1,66 @@
+import re
+
+# To learn about Buck see [Docs](https://buckbuild.com/).
+# To run your application with Buck:
+# - install Buck
+# - `npm start` - to start the packager
+# - `cd android`
+# - `cp ~/.android/debug.keystore keystores/debug.keystore`
+# - `./gradlew :app:copyDownloadableDepsToLibs` - make all Gradle compile dependencies available to Buck
+# - `buck install -r android/app` - compile, install and run application
+#
+
+lib_deps = []
+for jarfile in glob(['libs/*.jar']):
+  name = 'jars__' + re.sub(r'^.*/([^/]+)\.jar$', r'\1', jarfile)
+  lib_deps.append(':' + name)
+  prebuilt_jar(
+    name = name,
+    binary_jar = jarfile,
+  )
+
+for aarfile in glob(['libs/*.aar']):
+  name = 'aars__' + re.sub(r'^.*/([^/]+)\.aar$', r'\1', aarfile)
+  lib_deps.append(':' + name)
+  android_prebuilt_aar(
+    name = name,
+    aar = aarfile,
+  )
+
+android_library(
+  name = 'all-libs',
+  exported_deps = lib_deps
+)
+
+android_library(
+  name = 'app-code',
+  srcs = glob([
+    'src/main/java/**/*.java',
+  ]),
+  deps = [
+    ':all-libs',
+    ':build_config',
+    ':res',
+  ],
+)
+
+android_build_config(
+  name = 'build_config',
+  package = 'com.example',
+)
+
+android_resource(
+  name = 'res',
+  res = 'src/main/res',
+  package = 'com.example',
+)
+
+android_binary(
+  name = 'app',
+  package_type = 'debug',
+  manifest = 'src/main/AndroidManifest.xml',
+  keystore = '//android/keystores:debug',
+  deps = [
+    ':app-code',
+  ],
+)

--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -9,7 +9,7 @@ import com.android.build.OutputFile
  * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
  * bundle directly from the development server. Below you can see all the possible configurations
  * and their defaults. If you decide to add a configuration block, make sure to add it before the
- * `apply from: "react.gradle"` line.
+ * `apply from: "../../node_modules/react-native/react.gradle"` line.
  *
  * project.ext.react = [
  *   // the name of the generated asset file containing your JS bundle
@@ -59,7 +59,7 @@ import com.android.build.OutputFile
  * ]
  */
 
-apply from: "react.gradle"
+apply from: "../../node_modules/react-native/react.gradle"
 
 /**
  * Set this to true to create two separate APKs instead of one:
@@ -123,4 +123,11 @@ dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+  from configurations.compile
+  into 'libs'
 }

--- a/Example/package.json
+++ b/Example/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "^0.14.7",
-    "react-native": "^0.22.2",
+    "react-native": "^0.24.0-rc5",
     "react-native-button": "^1.2.1",
     "react-native-drawer": "^1.16.7",
     "react-native-modalbox": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-router-flux",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "description": "React Native Router using Flux architecture",
   "repository": {
     "type": "git",

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -100,6 +100,7 @@ export default class DefaultRenderer extends Component {
         const {key, direction, getSceneStyle} = props.scene.navigationState;
         let {panHandlers, animationStyle} = props.scene.navigationState;
 
+        // Since we always need to pass a style for the direction, we can avoid #526
         let style = {};
         if (getSceneStyle) style = getSceneStyle(props);
 

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -124,7 +124,6 @@ export default class DefaultRenderer extends Component {
                 style={[animationStyle, style]}
                 panHandlers={panHandlers}
                 renderScene={this._renderScene}
-                {...optionals}
             />
         );
     }

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -105,13 +105,13 @@ export default class DefaultRenderer extends Component {
 
         const isVertical = direction === "vertical";
 
-        if (!animationStyle) {
+        if (typeof(animationStyle) === 'undefined') {
             animationStyle = (isVertical ?
                 NavigationCardStackStyleInterpolator.forVertical(props) :
                 NavigationCardStackStyleInterpolator.forHorizontal(props));
         }
 
-        if (!panHandlers) {
+        if (typeof(panHandlers) === 'undefined') {
             panHandlers = panHandlers || (isVertical ?
                     NavigationCardStackPanResponder.forVertical(props) :
                     NavigationCardStackPanResponder.forHorizontal(props));

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -9,15 +9,13 @@
 import React, {Component, Animated, PropTypes, StyleSheet, View, NavigationExperimental} from "react-native";
 const {
     AnimatedView: NavigationAnimatedView,
-    Card: NavigationCard,
-    RootContainer: NavigationRootContainer,
-    Header: NavigationHeader,
-    } = NavigationExperimental;
+    Card: NavigationCard
+} = NavigationExperimental;
 
 const {
     CardStackPanResponder: NavigationCardStackPanResponder,
     CardStackStyleInterpolator: NavigationCardStackStyleInterpolator
-    } = NavigationCard;
+} = NavigationCard;
 
 import TabBar from "./TabBar";
 import NavBar from "./NavBar";
@@ -46,13 +44,13 @@ export default class DefaultRenderer extends Component {
             return null;
         }
         let Component = navigationState.component;
-        if (navigationState.tabs && !Component){
+        if (navigationState.tabs && !Component) {
             Component = TabBar;
         }
         if (Component) {
             return (
                 <View style={[{flex: 1}, navigationState.sceneStyle]}>
-                    <Component {...navigationState} navigationState={navigationState} />
+                    <Component {...navigationState} navigationState={navigationState}/>
                 </View>
             )
         }
@@ -93,14 +91,14 @@ export default class DefaultRenderer extends Component {
 
     _renderHeader(/*NavigationSceneRendererProps*/ props) {
         return <NavBar
-                {...props}
-                getTitle={state => state.title}
-            />;
+            {...props}
+            getTitle={state => state.title}
+        />;
     }
 
     _renderCard(/*NavigationSceneRendererProps*/ props) {
-        const { key, direction, getSceneStyle } = props.scene.navigationState;
-        let { panHandlers, animationStyle } = props.scene.navigationState;
+        const {key, direction, getSceneStyle} = props.scene.navigationState;
+        let {panHandlers, animationStyle} = props.scene.navigationState;
 
         let style = {};
         if (getSceneStyle) style = getSceneStyle(props);
@@ -108,15 +106,15 @@ export default class DefaultRenderer extends Component {
         const isVertical = direction === "vertical";
 
         if (!animationStyle) {
-          animationStyle = (isVertical ?
-            NavigationCardStackStyleInterpolator.forVertical(props) :
-            NavigationCardStackStyleInterpolator.forHorizontal(props));
+            animationStyle = (isVertical ?
+                NavigationCardStackStyleInterpolator.forVertical(props) :
+                NavigationCardStackStyleInterpolator.forHorizontal(props));
         }
 
         if (!panHandlers) {
-          panHandlers = panHandlers || (isVertical ?
-            NavigationCardStackPanResponder.forVertical(props) :
-            NavigationCardStackPanResponder.forHorizontal(props));
+            panHandlers = panHandlers || (isVertical ?
+                    NavigationCardStackPanResponder.forVertical(props) :
+                    NavigationCardStackPanResponder.forHorizontal(props));
         }
 
         return (
@@ -140,6 +138,6 @@ export default class DefaultRenderer extends Component {
 const styles = StyleSheet.create({
     animatedView: {
         flex: 1,
-        backgroundColor:"transparent"
+        backgroundColor: "transparent"
     },
 });


### PR DESCRIPTION
Upgraded the Example project, merged in #503 and additional changes. Removed unneeded optionals. 

I tried for a couple of hours to find the cause of type="replace" and type="reset" no longer working but it's proven elusive. It doesn't affect the UIExplorer in the react-native examples folder, so it remains likely this is a bug in our implementation of NavigationExperimental. 

Would love any additional eyes on this.