### PR TITLE
Implement FOCUS_ACTION using createReducer approach

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -44,14 +44,14 @@ class Actions {
         this.init = this.init.bind(this);
         this.pop = this.pop.bind(this);
         this.refresh = this.refresh.bind(this);
-
+        this.focus = this.focus.bind(this);
     }
 
     iterate(root: Scene, parentProps = {}, refs = {}) {
         assert(root.props, "props should be defined for stack");
         const key = root.key || "root";
         assert(key, "unique key should be defined ",root);
-        assert([POP_ACTION, POP_ACTION2, REFRESH_ACTION, REPLACE_ACTION, JUMP_ACTION, PUSH_ACTION, RESET_ACTION, "create",
+        assert([POP_ACTION, POP_ACTION2, REFRESH_ACTION, REPLACE_ACTION, JUMP_ACTION, PUSH_ACTION, FOCUS_ACTION, RESET_ACTION, "create",
                 "init","callback","iterate","current"].indexOf(key)==-1, key+" is not allowed as key name");
         const {children, ...staticProps} = root.props;
         let type = root.props.type || (parentProps.tabs ? JUMP_ACTION : PUSH_ACTION);
@@ -104,6 +104,11 @@ class Actions {
     refresh(props = {}){
         props = filterParam(props);
         this.callback && this.callback({...props, type: REFRESH_ACTION});
+    }
+
+    focus(props = {}){
+      props = filterParam(props);
+      this.callback && this.callback({...props, type: FOCUS_ACTION});
     }
 
     create(scene:Scene){

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -15,6 +15,7 @@ const {
     } = NavigationExperimental;
 import TabBar from "./TabBar";
 import NavBar from "./NavBar";
+import Actions from './Actions';
 
 export default class DefaultRenderer extends Component {
     constructor(props) {
@@ -53,6 +54,7 @@ export default class DefaultRenderer extends Component {
 
         const selected = navigationState.children[navigationState.index];
         //return <DefaultRenderer key={selected.key} navigationState={selected}/>
+        Actions.focus({scene: selected});
 
         let applyAnimation = selected.applyAnimation || navigationState.applyAnimation;
         let style = selected.style || navigationState.style;

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -29,6 +29,24 @@ export default class DefaultRenderer extends Component {
         navigationState: PropTypes.any,
     };
 
+    componentDidMount() {
+        this.dispatchFocusAction(this.props);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.navigationState !== this.props.navigationState) {
+          this.dispatchFocusAction(nextProps);
+        }
+    }
+
+    dispatchFocusAction({navigationState}) {
+        if (!navigationState || navigationState.component || navigationState.tabs) {
+            return;
+        }
+        const scene = navigationState.children[navigationState.index];
+        Actions.focus({scene});
+    }
+
     getChildContext() {
         return {
             navigationState: this.props.navigationState,
@@ -54,7 +72,6 @@ export default class DefaultRenderer extends Component {
 
         const selected = navigationState.children[navigationState.index];
         //return <DefaultRenderer key={selected.key} navigationState={selected}/>
-        Actions.focus({scene: selected});
 
         let applyAnimation = selected.applyAnimation || navigationState.applyAnimation;
         let style = selected.style || navigationState.style;

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -7,7 +7,7 @@
  *
  */
 
-import {PUSH_ACTION, POP_ACTION2, FOCUS_ACTION, JUMP_ACTION, INIT_ACTION, REPLACE_ACTION, RESET_ACTION, POP_ACTION, REFRESH_ACTION} from "./Actions";
+import {PUSH_ACTION, POP_ACTION2, JUMP_ACTION, INIT_ACTION, REPLACE_ACTION, RESET_ACTION, POP_ACTION, REFRESH_ACTION} from "./Actions";
 import assert from "assert";
 import {getInitialState} from "./State";
 


### PR DESCRIPTION
This is an alternative approach to #531 that follows @aksonov's intended implementation.

### Problem

My app needs to know which screen is currently in focus. Because the *_FOCUS actions were removed in v3, this is no longer possible.

### Solution

Implement the FOCUS_ACTION action. The action payload contains the props for the screen that is currently in focus (name, title, etc.).

### Usage

~~~js
// actions/routes.js

export const FOCUS_ACTION = 'FOCUS_ACTION';

export function focus(scene) {
  return {type: FOCUS_ACTION, scene};
}
~~~

~~~js
// reducers/routes.js
import { createReducer } from 'redux-immutablejs';
import Immutable from 'immutable';
import {FOCUS_ACTION} from '../actions/routes';

const initialState = Immutable.fromJS({
  scene: {},
});

export default createReducer(initialState, {
  [FOCUS_ACTION]: (state, {scene}) => state.merge({scene}),
});
~~~

~~~js
// routes.js

import {focus} from './actions/routes';
// other imports...

class Routes extends React.Component {
  static propTypes = {
    dispatch: PropTypes.func,
  };

  reducerCreate(params) {
    const defaultReducer = Reducer(params);
    return (state, action) => {
      if (action.type === 'focus') {
        this.props.dispatch(focus(action.scene))
      }
      return defaultReducer(state, action);
    };
  }

  render () {
    return (
      <Router
        createReducer={this.reducerCreate.bind(this)}
        scenes={scenes} />
    );
  }
}

export default connect()(Routes);
~~~

~~~js
// app.js

import Routes from './routes';
// other imports...

// create store...

class App extends React.Component {
  render () {
    return (
      <Provider store={store}>
        <Routes />
      </Provider>
    );
  }
}
~~~