### PR TITLE
renderRightButton and renderLeftButton takes selected component as argument

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -65,7 +65,7 @@ export default class NavBar extends React.Component {
             <Animated.View
                 style={[styles.header, state.navigationBarStyle, selected.navigationBarStyle]}>
                 {state.children.map(this._renderTitle, this)}
-                {renderLeftButton(selected) || renderBackButton()}
+                {renderLeftButton(selected) || renderBackButton(selected)}
                 {renderRightButton(selected)}
             </Animated.View>
         );

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -65,8 +65,8 @@ export default class NavBar extends React.Component {
             <Animated.View
                 style={[styles.header, state.navigationBarStyle, selected.navigationBarStyle]}>
                 {state.children.map(this._renderTitle, this)}
-                {renderLeftButton() || renderBackButton()}
-                {renderRightButton()}
+                {renderLeftButton(selected) || renderBackButton()}
+                {renderRightButton(selected)}
             </Animated.View>
         );
     }


### PR DESCRIPTION
Including the selected child lets the renderRight and Left buttons be able to render based on the child's state.

```javascript
  renderRightButton={(props)=>{ <RightButton item={props.item}/> } }
```
This can help with item counts, save/create state for items that are
existing vs new, and more.

Right now this uses 'selected' which includes the entire component,
it would probably be more suitable to include just the props of that
component but I'm not sure that's possible at that point in time.

Additionally, this should provide a way to solve:

* https://github.com/aksonov/react-native-router-flux/issues/213
* https://github.com/aksonov/react-native-router-flux/issues/478