### PR TITLE
Adding an option to compute title for each screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ class App extends React.Component {
 | sceneStyle | View style | { flex: 1 } | optional style override for the Scene's component |
 | other props | | | all properties that will be passed to your component instance |
 | getSceneStyle | function | optional | Optionally override the styles for NavigationCard's Animated.View rendering the scene. |
+| getTitle | function | optional | Optionally closure to return a value of the title based on state
 | renderTitle | function | optional | Optionally closure to render the title
+
 ## Example
 ![launch](https://cloud.githubusercontent.com/assets/1321329/11692367/7337cfe2-9e9f-11e5-8515-e8b7a9f230ec.gif)
 

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -110,7 +110,8 @@ export default class DefaultRenderer extends Component {
       selected = selected.children[selected.index];
     }
     const Component = state.navBar || selected.navBar || NavBar;
-    return <Component {...props} getTitle={state => state.title} />;
+    const getTitle = selected.getTitle || ( state => state.title )
+    return <Component {...props} getTitle={getTitle} />
   }
 
   _renderCard(/* NavigationSceneRendererProps*/ props) {


### PR DESCRIPTION
This allows things like opening a detail view (in master-detail)
with the detail navbar title populated with the name of the item the user is
currently editing.

For example:

```
getTitle={(comp)=> comp.item ? comp.item.get('title') : "" }
```
Once the scene is navigated to, the navbar will use this specific
getTitle function, which will return a different title, based on
the navigation parameters that were used in order to navigate to it.