### PR TITLE
Fix Reset and Replace

### DIFF
--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -95,12 +95,24 @@ function inject(state, action, props, scenes) {
       if (state.children[state.index].sceneKey === action.key) {
         return state;
       }
-      return { ...state,
-        children: [...state.children.slice(0, -1),
-          getInitialState(props, scenes, state.index, action)] };
+
+      state.children[state.children.length - 1] = getInitialState(props, scenes, state.index, action);
+
+      return { ...state, children: state.children };
     case RESET_ACTION:
-      return { ...state, index: 0,
-        children: [getInitialState(props, scenes, state.index, action)] };
+      if (state.children[state.index].sceneKey === action.key) {
+        return state;
+      }
+
+      state.children = state.children.splice(0, 1);
+      state.children[0] = getInitialState(props, scenes, state.index, action);
+
+      return {
+        ...state,
+        index: 0,
+        from: null,
+        children: state.children,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
React-Native: 0.24.1
Compatible with 0.22+

Updates existing state children with new scenes so that it forces a re-render of the scene rather than removing the object which leaves the previous scene in the view.