### PR TITLE
Send all props through to renderNavigationBar and renderTitle through props

### DIFF
--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -106,7 +106,7 @@ export default class DefaultRenderer extends Component {
     }
 
     if (selected.component && selected.component.renderNavigationBar) {
-      return selected.component.renderNavigationBar({ ...this.props, ...selected });
+      return selected.component.renderNavigationBar({ ...props, ...selected });
     }
 
     const HeaderComponent = selected.navBar || child.navBar || state.navBar || NavBar;

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -370,7 +370,8 @@ class NavBar extends React.Component {
       selected.component.renderBackButton ||
       this.renderBackButton;
     const renderTitle = selected.renderTitle ||
-      selected.component.renderTitle;
+      selected.component.renderTitle ||
+      this.props.renderTitle;
     return (
       <Animated.View
         style={[


### PR DESCRIPTION
I have a custom extension to the default NavBar through `renderNavigationBar(props)` which, in turn, renders a custom title by passing `renderTitle` through a prop, leading to the change to NavBar.js.

In addition, there is the need for the `NavigationSceneRendererProps` to be passed to the custom title component to use the `AnimatedValue: position` within the `AnimatedView` (see: [here](https://gist.github.com/brentvatne/52af349a6b6ef2ee1b06#navigationheader)).