### PR TITLE
Fix for #664 navigationState issue on RN 0.24.1

### DIFF
--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -64,6 +64,14 @@ export default class DefaultRenderer extends Component {
       return;
     }
     const scene = navigationState.children[navigationState.index];
+    // (temp or production?) Fix for #664
+    if (navigationState.index == 1) {
+      // Make sure the key names are not the same, or error will be thrown.
+      if (scene.key === navigationState.children[navigationState.index-1].key) {
+        // Change the new key name (just add current index to end of scene.key)
+        scene.key = scene.key+=navigationState.index;
+      }
+    }
     Actions.focus({ scene });
   }
 

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -65,7 +65,7 @@ export default class DefaultRenderer extends Component {
     }
     const scene = navigationState.children[navigationState.index];
     // (temp or production?) Fix for #664
-    if (navigationState.index == 1) {
+    if (navigationState.index > 0) {
       // Make sure the key names are not the same, or error will be thrown.
       if (scene.key === navigationState.children[navigationState.index-1].key) {
         // Change the new key name (just add current index to end of scene.key)


### PR DESCRIPTION
When pushing a new scene, there was an issue where the `scene.key` (`navigationState.children[navigationState.index].key`) would be conflict with the previous `scene.key` value.

What my piece of code does is make sure that the current `scene.key` is != the previous `scene.key`, if they're the same, then I add the `navigationState.index` to the end of the `scene.key` value, resulting in no conflict errors being thrown. 

Refer to this issue for more details:
#664 