### PR TITLE
was literal 'position' a typo?

### DIFF
--- a/src/State.js
+++ b/src/State.js
@@ -42,7 +42,7 @@ export function getInitialState(
     return {
       ...scenes.rootProps,
       ...route,
-      key: `position_${route.sceneKey}`,
+      key: `${position}_${route.sceneKey}`,
       ...parentProps,
       ...getStateFromScenes(route, scenes, props),
     };


### PR DESCRIPTION
I'm not sure, so if someone could, please review if this is a safe change.

I think this is related to https://github.com/aksonov/react-native-router-flux/issues/664 and might be the right fix instead of https://github.com/aksonov/react-native-router-flux/pull/665 if the way I'm thinking about it is correct.