### PR TITLE
Force assert dependencies to version 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   ],
   "dependencies": {
-    "assert": "^1.3.0",
+    "assert": "1.3.0",
     "react-native-tabs": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Using assert version 1.4.0 generates "Unable to resolve module buffer..." error.

![image](https://cloud.githubusercontent.com/assets/1885333/15365019/07f267a4-1cf5-11e6-87a2-16fe9679a4c7.png)
