### PR TITLE
UPDATE: Pop tab children when tab is selected

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "15.0.2",
-    "react-native": "^0.26.1",
+    "react-native": "^0.26.0",
     "react-native-button": "github:ide/react-native-button",
     "react-native-drawer": "^2.2.2",
     "react-native-modalbox": "^1.3.3",

--- a/Example/package.json
+++ b/Example/package.json
@@ -7,8 +7,8 @@
     "sync-rnrf": "rm -rf ./node_modules/react-native-router-flux; sane '/usr/bin/rsync -v -a --exclude .git --exclude Example --exclude node_modules ../ ./node_modules/react-native-router-flux/' .. --glob='{**/*.json,**/*.js}'"
   },
   "dependencies": {
-    "react": "^15.0.2",
-    "react-native": "^0.26.0",
+    "react": "15.0.2",
+    "react-native": "^0.26.1",
     "react-native-button": "github:ide/react-native-button",
     "react-native-drawer": "^2.2.2",
     "react-native-modalbox": "^1.3.3",

--- a/docs/API_CONFIGURATION.md
+++ b/docs/API_CONFIGURATION.md
@@ -51,6 +51,7 @@
 | tabs| `bool` | false | Defines 'TabBar' scene container, so child scenes will be displayed as 'tabs'. If no `component` is defined, built-in `TabBar` is used as renderer. All child scenes are wrapped into own navbar.
 | tabBarStyle | [`View style`](https://facebook.github.io/react-native/docs/view.html#style) |  | optional style override for the Tabs component |
 | hideTabBar | `bool` | false | hides tab bar for this scene (if built-in TabBar component is used as parent renderer)|
+| popChildrenOnSelect | `bool` | false | Pop all children in the stack to go back to the initial scene for this tab when it is selected again. |
 
 ### Navigation Bar
 | Property | Type | Default | Description |

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -26,11 +26,12 @@ class TabBar extends Component {
       If the prop `popChildrenOnSelect` is set to true on the tab child Scene,
       then pop all children in the stack to go back to the initial scene for
       this tab when it is selected again.
-     */
-    if (el.props.popChildrenOnSelect) {
-      el.props.children.forEach(() => {
-        Actions.pop();
-      });
+    */
+
+    if (el.popChildrenOnSelect) {
+     el.children.forEach((obj) => {
+       Actions.pop();
+     });
     }
 
     Actions[el.sceneKey]();

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -27,10 +27,10 @@ class TabBar extends Component {
       then pop all children in the stack to go back to the initial scene for
       this tab when it is selected again.
      */
-    if(el.props.popChildrenOnSelect) {
-      el.props.children.forEach((obj) => {
+    if (el.props.popChildrenOnSelect) {
+      el.props.children.forEach(() => {
         Actions.pop();
-      })
+      });
     }
 
     Actions[el.sceneKey]();

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -21,6 +21,18 @@ class TabBar extends Component {
         `No action is defined for sceneKey=${el.sceneKey} ` +
         `actions: ${JSON.stringify(Object.keys(Actions))}`);
     }
+
+    /*
+      If the prop `popChildrenOnSelect` is set to true on the tab child Scene,
+      then pop all children in the stack to go back to the initial scene for
+      this tab when it is selected again.
+     */
+    if(el.props.popChildrenOnSelect) {
+      el.props.children.forEach((obj) => {
+        Actions.pop();
+      })
+    }
+
     Actions[el.sceneKey]();
   }
 


### PR DESCRIPTION
Fixes https://github.com/aksonov/react-native-router-flux/issues/717 by adding a prop (default: false, see updated docs) `popChildrenOnSelect`

If the prop `popChildrenOnSelect` is set to true on the tab child Scene, then pop all children in the stack to go back to the initial scene for this tab when it is selected again.

I have also fixed an issue where React `15.1.0` was being updated in new installs of Example, causing an error `super expression must either be null or a function not undefined`