### PR TITLE
Fix Typo in Switch referring to this.props

### DIFF
--- a/src/Switch.js
+++ b/src/Switch.js
@@ -13,7 +13,7 @@ export default function Switch(props) {
   if (!navigationState) console.error(`Cannot find a scene with key “${selectedKey}”`);
   return (
     <DefaultRenderer
-      onNavigate={this.props.onNavigate}
+      onNavigate={props.onNavigate}
       navigationState={navigationState}
     />
   );


### PR DESCRIPTION
It looks like this reference was missed in the conversion to a functional component.