### PR TITLE
Added section about Relay support with example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ And then:
 * `Actions.pop()` will pop the current screen.
 * `Actions.refresh(PARAMS)` will update the properties of the current screen.
 
+## Is Relay supported?
+Yes, it is! You can use `wrapBy` parameter to pass you own relay wrapper for rendering Relay components.
+Check [react-native-router-flux + relay example app](https://github.com/r0b1n/rnrf-relay-example) to find out how it works.
+
 ## Production Apps using react-native-router-flux
 + GuavaPass.com ([iOS](https://itunes.apple.com/en/app/guavapass-one-pass-fitness/id1050491044?l=en&mt=8), Android) - offers convenient access to top classes at boutique fitness studios across Asia.
 + Epic Fail Videos ([iOS](https://itunes.apple.com/us/app/epic-fail-videos-best-fail/id1115219339), [Android](https://play.google.com/store/apps/details?id=com.hazuu.epicfailvideos)) - The best Fail Videos Collection, never miss a laugh with your friends!


### PR DESCRIPTION
As asked in this issue: https://github.com/aksonov/react-native-router-flux/issues/437
Added section about Relay.
