### PR TITLE
remove unneeded dependency

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -11,7 +11,6 @@
     "react-native": "0.26.x",
     "react-native-button": "github:ide/react-native-button",
     "react-native-drawer": "^2.2.2",
-    "react-native-modalbox": "^1.3.3",
     "react-native-router-flux": "file:../"
   },
   "devDependencies": {


### PR DESCRIPTION
I was wondering where in the example modalbox is used. Turns out running `git grep modalbox` gives a single result - the package file.