### PR TITLE
[actions]: add support when dealing Scenes defined using array map

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -67,7 +67,7 @@ class Actions {
     assert(key, 'unique key should be defined ');
     assert(
       reservedKeys.indexOf(key) === -1,
-      `'${key}' is not allowed as key name. Reserved keys: [${reservedKeys.join(', ')}]`,
+      `'${key}' is not allowed as key name. Reserved keys: [${reservedKeys.join(', ')}]`
     );
     const { children, component, ...staticProps } = root.props;
     let type = root.props.type || (parentProps.tabs ? JUMP_ACTION : PUSH_ACTION);
@@ -96,10 +96,22 @@ class Actions {
       ...staticProps,
       ...componentProps,
     };
-    let list = children || [];
+    let list = children || [],
+        normalized = [];
     if (!(list instanceof Array)) {
-      list = [list];
+        list = [list];
     }
+    list.forEach(item=> {
+        if (item instanceof Array) {
+            item.forEach(it=> {
+                normalized.push(it);
+            })
+        } else {
+            normalized.push(item);
+        }
+    });
+    list = normalized; // normalize the list of scenes
+
     const condition = el => (!el.props.component && !el.props.children &&
     (!el.props.type || el.props.type === REFRESH_ACTION));
     // determine sub-states

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -96,19 +96,19 @@ class Actions {
       ...staticProps,
       ...componentProps,
     };
-    let list = children || [],
-        normalized = [];
+    let list = children || [];
+    const normalized = [];
     if (!(list instanceof Array)) {
-        list = [list];
+      list = [list];
     }
-    list.forEach(item=> {
-        if (item instanceof Array) {
-            item.forEach(it=> {
-                normalized.push(it);
-            })
-        } else {
-            normalized.push(item);
-        }
+    list.forEach(item => {
+      if (item instanceof Array) {
+        item.forEach(it => {
+          normalized.push(it);
+        });
+      } else {
+        normalized.push(item);
+      }
     });
     list = normalized; // normalize the list of scenes
 


### PR DESCRIPTION
In the render function when defining the Scenes, if you use 
{ myViewsArray.map((item, index)=>this.buildNavScenes(item, index)) } it work with this small fix, without needing to enclose this into an additional Scene