### PR TITLE
Feature Hand Back Key for Android

### DIFF
--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -75,9 +75,9 @@ function inject(state, action, props, scenes) {
       assert(!state.tabs, 'pop() operation cannot be run on tab bar (tabs=true)');
 
       if (Platform.OS === 'android') {
-        assert(state.index > 0, 'You are already in the root scene.')
+        assert(state.index > 0, 'You are already in the root scene.');
       }
-      
+
       if (state.index === 0) {
         return state;
       }

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -22,6 +22,7 @@ import {
 
 import { assert } from './Util';
 import { getInitialState } from './State';
+import { Platform } from 'react-native';
 
 // WARN: it is not working correct. rewrite it.
 function checkPropertiesEqual(action, lastAction) {
@@ -72,6 +73,11 @@ function inject(state, action, props, scenes) {
     case POP_ACTION2:
     case POP_ACTION: {
       assert(!state.tabs, 'pop() operation cannot be run on tab bar (tabs=true)');
+
+      if (Platform.OS === 'android') {
+        assert(state.index > 0, 'You are already in the root scene.')
+      }
+      
       if (state.index === 0) {
         return state;
       }

--- a/src/Router.js
+++ b/src/Router.js
@@ -10,6 +10,7 @@ import React, {
   Component,
   PropTypes,
 } from 'react';
+import { BackAndroid } from 'react-native'
 import NavigationExperimental from 'react-native-experimental-navigation';
 
 import Actions from './Actions';
@@ -97,6 +98,16 @@ class Router extends Component {
 
   render() {
     if (!this.state.reducer) return null;
+
+    BackAndroid.addEventListener('hardwareBackPress', () => {
+      try {
+        Actions.pop();
+        return true;
+      }
+      catch (err) {
+        return false;
+      }
+    })
 
     return (
       <NavigationRootContainer

--- a/src/Router.js
+++ b/src/Router.js
@@ -10,7 +10,7 @@ import React, {
   Component,
   PropTypes,
 } from 'react';
-import { BackAndroid } from 'react-native'
+import { BackAndroid } from 'react-native';
 import NavigationExperimental from 'react-native-experimental-navigation';
 
 import Actions from './Actions';
@@ -107,7 +107,7 @@ class Router extends Component {
       catch (err) {
         return false;
       }
-    })
+    });
 
     return (
       <NavigationRootContainer

--- a/src/Router.js
+++ b/src/Router.js
@@ -103,8 +103,7 @@ class Router extends Component {
       try {
         Actions.pop();
         return true;
-      }
-      catch (err) {
+      } catch (err) {
         return false;
       }
     });


### PR DESCRIPTION
For know, RNRF doesn't handle back kay on Android. App will exit anyway when you press the back key, no matter which scene you are at. This pull request handles the back key action. It will pop current scene when you press back key, and throw a error when you are on the root scene on Android, then the BackAndroid will cache the error and exit the app.