### PR TITLE
Default left button size unless size is overwritten

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -323,6 +323,7 @@ class NavBar extends React.Component {
       const style = [styles.leftButton, self.props.leftButtonStyle, state.leftButtonStyle];
       const textStyle = [styles.barLeftButtonText, self.props.leftButtonTextStyle,
         state.leftButtonTextStyle];
+      const leftButtonStyle = [styles.defaultImageStyle, state.leftButtonIconStyle];
 
       if (state.leftButton) {
         let Button = state.leftButton;
@@ -350,7 +351,7 @@ class NavBar extends React.Component {
           menuIcon = (
             <Image
               source={buttonImage}
-              style={state.leftButtonIconStyle || styles.defaultImageStyle}
+              style={leftButtonStyle}
             />
           );
         }


### PR DESCRIPTION
I think it makes sense to default the height and resize mode for the drawer icon unless someone explicitly overwrites it.  That lets me set the tint color without also having to manually specify the size and resize mode.