### PR TITLE
Fix NavBar backButtonImage propType

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -153,7 +153,7 @@ const styles = StyleSheet.create({
 
 const propTypes = {
   navigationState: PropTypes.object,
-  backButtonImage: PropTypes.number,
+  backButtonImage: Image.propTypes.source,
   wrapBy: PropTypes.any,
   component: PropTypes.any,
   backButtonTextStyle: Text.propTypes.style,


### PR DESCRIPTION
Docs mention that backButtonImage is Image source, but actually it's `number` in the file https://github.com/aksonov/react-native-router-flux/blob/master/docs/API_CONFIGURATION.md#navigation-bar-back-button

# Before
got warning
![screenshot 2016-06-15 18 48 31](https://cloud.githubusercontent.com/assets/1104313/16103214/51aeb306-332b-11e6-9daa-a9cab57da521.png)

# After
no warnings and back button can be set
![screenshot 2016-06-15 19 01 07](https://cloud.githubusercontent.com/assets/1104313/16103239/8e95a0c2-332b-11e6-8394-483c05a7ff9e.png)
