### PR TITLE
Prefix action strings to namespace them.

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -8,15 +8,15 @@
  */
 import { assert } from './Util';
 import Scene from './Scene';
-export const JUMP_ACTION = 'router_jump';
-export const PUSH_ACTION = 'router_push';
-export const REPLACE_ACTION = 'router_replace';
-export const POP_ACTION2 = 'router_back';
-export const POP_ACTION = 'router_BackAction';
-export const POP_TO = 'router_popTo';
-export const REFRESH_ACTION = 'router_refresh';
-export const RESET_ACTION = 'router_reset';
-export const FOCUS_ACTION = 'router_focus';
+export const JUMP_ACTION = 'REACT_NATIVE_ROUTER_FLUX_JUMP';
+export const PUSH_ACTION = 'REACT_NATIVE_ROUTER_FLUX_PUSH';
+export const REPLACE_ACTION = 'REACT_NATIVE_ROUTER_FLUX_REPLACE';
+export const POP_ACTION2 = 'REACT_NATIVE_ROUTER_FLUX_BACK';
+export const POP_ACTION = 'REACT_NATIVE_ROUTER_FLUX_BACK_ACTION';
+export const POP_TO = 'REACT_NATIVE_ROUTER_FLUX_POP_TO';
+export const REFRESH_ACTION = 'REACT_NATIVE_ROUTER_FLUX_REFRESH';
+export const RESET_ACTION = 'REACT_NATIVE_ROUTER_FLUX_RESET';
+export const FOCUS_ACTION = 'REACT_NATIVE_ROUTER_FLUX_FOCUS';
 
 function filterParam(data) {
   if (data.toString() !== '[object Object]') {

--- a/test/Reducer.test.js
+++ b/test/Reducer.test.js
@@ -67,11 +67,11 @@ describe('createReducer', () => {
       type: 'router_push',
       param1: 'Hello world',
     });
-    
+
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('conversations');
     expect(currentScene.sceneKey).equal('conversations');
-    expect(currentScene.type).equal('push');
+    expect(currentScene.type).equal('router_push');
     expect(currentScene.param1).equal('Hello world');
 
     latestState = reducer(latestState, {
@@ -82,7 +82,7 @@ describe('createReducer', () => {
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('loginModal1');
     expect(currentScene.sceneKey).equal('loginModal1');
-    expect(currentScene.type).equal('push');
+    expect(currentScene.type).equal('router_push');
     expect(currentScene.param2).equal('Hello world2');
 
     latestState = reducer(latestState, {
@@ -93,7 +93,7 @@ describe('createReducer', () => {
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('privacyPolicy');
     expect(currentScene.sceneKey).equal('privacyPolicy');
-    expect(currentScene.type).equal('push');
+    expect(currentScene.type).equal('router_push');
     expect(currentScene.param3).equal('Accept policy');
 
     latestState = reducer(latestState, {

--- a/test/Reducer.test.js
+++ b/test/Reducer.test.js
@@ -64,9 +64,10 @@ describe('createReducer', () => {
     // Normally actions came from Actions module, but we will generate it manually.
     latestState = reducer(latestState, {
       key: 'conversations',
-      type: 'push',
+      type: 'router_push',
       param1: 'Hello world',
     });
+    
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('conversations');
     expect(currentScene.sceneKey).equal('conversations');
@@ -75,7 +76,7 @@ describe('createReducer', () => {
 
     latestState = reducer(latestState, {
       key: 'login', // we go to `login` but first renderable child is `loginModal1`
-      type: 'push',
+      type: 'router_push',
       param2: 'Hello world2',
     });
     currentScene = getCurrent(latestState);
@@ -86,7 +87,7 @@ describe('createReducer', () => {
 
     latestState = reducer(latestState, {
       key: 'privacyPolicy',
-      type: 'push',
+      type: 'router_push',
       param3: 'Accept policy',
     });
     currentScene = getCurrent(latestState);
@@ -97,13 +98,13 @@ describe('createReducer', () => {
 
     latestState = reducer(latestState, {
       key: 'cubeBar', // we go to cubeBar but first renderable child is `conversations`
-      type: 'push',
+      type: 'router_push',
       param1: 'Conversations new param',
     });
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('conversations');
     expect(currentScene.sceneKey).equal('conversations');
-    expect(currentScene.type).equal('push');
+    expect(currentScene.type).equal('router_push');
     expect(currentScene.param1).equal('Conversations new param');
   });
 });

--- a/test/Reducer.test.js
+++ b/test/Reducer.test.js
@@ -64,47 +64,47 @@ describe('createReducer', () => {
     // Normally actions came from Actions module, but we will generate it manually.
     latestState = reducer(latestState, {
       key: 'conversations',
-      type: 'router_push',
+      type: 'REACT_NATIVE_ROUTER_FLUX_PUSH',
       param1: 'Hello world',
     });
 
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('conversations');
     expect(currentScene.sceneKey).equal('conversations');
-    expect(currentScene.type).equal('router_push');
+    expect(currentScene.type).equal('REACT_NATIVE_ROUTER_FLUX_PUSH');
     expect(currentScene.param1).equal('Hello world');
 
     latestState = reducer(latestState, {
       key: 'login', // we go to `login` but first renderable child is `loginModal1`
-      type: 'router_push',
+      type: 'REACT_NATIVE_ROUTER_FLUX_PUSH',
       param2: 'Hello world2',
     });
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('loginModal1');
     expect(currentScene.sceneKey).equal('loginModal1');
-    expect(currentScene.type).equal('router_push');
+    expect(currentScene.type).equal('REACT_NATIVE_ROUTER_FLUX_PUSH');
     expect(currentScene.param2).equal('Hello world2');
 
     latestState = reducer(latestState, {
       key: 'privacyPolicy',
-      type: 'router_push',
+      type: 'REACT_NATIVE_ROUTER_FLUX_PUSH',
       param3: 'Accept policy',
     });
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('privacyPolicy');
     expect(currentScene.sceneKey).equal('privacyPolicy');
-    expect(currentScene.type).equal('router_push');
+    expect(currentScene.type).equal('REACT_NATIVE_ROUTER_FLUX_PUSH');
     expect(currentScene.param3).equal('Accept policy');
 
     latestState = reducer(latestState, {
       key: 'cubeBar', // we go to cubeBar but first renderable child is `conversations`
-      type: 'router_push',
+      type: 'REACT_NATIVE_ROUTER_FLUX_PUSH',
       param1: 'Conversations new param',
     });
     currentScene = getCurrent(latestState);
     expect(currentScene.name).equal('conversations');
     expect(currentScene.sceneKey).equal('conversations');
-    expect(currentScene.type).equal('router_push');
+    expect(currentScene.type).equal('REACT_NATIVE_ROUTER_FLUX_PUSH');
     expect(currentScene.param1).equal('Conversations new param');
   });
 });


### PR DESCRIPTION
I noticed the action constants are very generic strings (not namespaced like 'router_jump' etc.):
```
export const JUMP_ACTION = 'jump';
export const PUSH_ACTION = 'push';
export const REPLACE_ACTION = 'replace';
export const POP_ACTION2 = 'back';
export const POP_ACTION = 'BackAction';
export const REFRESH_ACTION = 'refresh';
export const RESET_ACTION = 'reset';
export const FOCUS_ACTION = 'focus';
```
As I understand Redux, all actions get passed to all reducers when you use `combineReducers`. We see these strings as being so generic that it opens a very real risk of me (or another module I did not read) dispatching an action that evaluates to the same string, triggering an action that was not supposed to be triggered. To prevent this I propose the following change, or any other that diminishes this risk.

At the moment this is not an issue with Redux as we are unable to combine both stores (probably only possible with MobX at the moment?), but as RNRF becomes store agnostic we would need something like this.