### PR TITLE
Replace `assert` in Switch.js with custom `assert`

### DIFF
--- a/src/Switch.js
+++ b/src/Switch.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import TabBar from './TabBar';
-import assert from 'assert';
+import { assert } from './Util';
 
 export default function Switch(props) {
   const navState = props.navigationState;


### PR DESCRIPTION
It breaks the component because `assert` is no longer in the dependencies..