### PR TITLE
Cleanup babel dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,9 @@
     "react-static-container": "1.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
     "babel-core": "^6.7.6",
-    "babel-eslint": "^6.0.3",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
+    "babel-eslint": "^6.1.0",
     "babel-preset-react-native": "^1.5.6",
-    "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "enzyme": "^2.1.0",


### PR DESCRIPTION
Update `babel-eslint` and remove unnecessary dependencies.

Fixes #635.