### PR TITLE
Allow for one scene to fade into the next in addition to horizontal/vertical

### DIFF
--- a/docs/API_CONFIGURATION.md
+++ b/docs/API_CONFIGURATION.md
@@ -37,6 +37,8 @@
 |-----------|--------|---------|--------------------------------------------|
 | duration | `number` | | optional. acts as a shortcut to writing an `applyAnimation` function with `Animated.timing` for a given duration (in ms). |
 | direction | `string` | 'horizontal' | direction of animation horizontal/vertical |
+| animation | `string` | | animation options when transitioning: 'fade' currently only option |
+| animationStyle | `function` | | optional interpolation function for scene transitions: `animationStyle={interpolationFunction}` |
 | applyAnimation | `function` | | optional if provided overrides the default spring animation |
 
 ### Scene styles

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -128,7 +128,7 @@ export default class DefaultRenderer extends Component {
   }
 
   renderCard(/* NavigationSceneRendererProps */ props) {
-    const { key, direction, getSceneStyle } = props.scene.navigationState;
+    const { key, direction, animation, getSceneStyle } = props.scene.navigationState;
     let { panHandlers, animationStyle } = props.scene.navigationState;
 
     const state = props.navigationState;
@@ -148,8 +148,15 @@ export default class DefaultRenderer extends Component {
 
     const isVertical = direction === 'vertical';
 
+    // direction overrides animation if both are supplied
+    const animType = (animation && !direction) ? animation : direction;
+
     if (typeof(animationStyle) === 'undefined') {
-      animationStyle = this.chooseInterpolator(direction, props);
+      animationStyle = this.chooseInterpolator(animType, props);
+    }
+
+    if (typeof(animationStyle) === 'function') {
+      animationStyle = animationStyle(props);
     }
 
     if (typeof(panHandlers) === 'undefined') {

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -41,6 +41,41 @@ const styles = StyleSheet.create({
   },
 });
 
+function fadeInScene(/* NavigationSceneRendererProps */ props) {
+  const {
+    layout,
+    position,
+    scene,
+  } = props;
+
+  const index = scene.index;
+  const inputRange = [index - 1, index, index + 1];
+  const width = layout.initWidth;
+  const height = layout.initHeight;
+
+  const opacity = position.interpolate({
+    inputRange,
+    outputRange: [0, 1, 0.3],
+  });
+
+  const scale = position.interpolate({
+    inputRange,
+    outputRange: [1, 1, 0.95],
+  });
+
+  const translateY = 0;
+  const translateX = 0;
+
+  return {
+    opacity,
+    transform: [
+      { scale },
+      { translateX },
+      { translateY },
+    ],
+  };
+}
+
 export default class DefaultRenderer extends Component {
 
   static propTypes = {
@@ -104,11 +139,12 @@ export default class DefaultRenderer extends Component {
     const style = getSceneStyle ? getSceneStyle(props, computedProps) : null;
 
     const isVertical = direction === 'vertical';
+    const isFade = direction === 'fade';
 
     if (typeof(animationStyle) === 'undefined') {
       animationStyle = (isVertical ?
         NavigationCardStackStyleInterpolator.forVertical(props) :
-        NavigationCardStackStyleInterpolator.forHorizontal(props));
+        isFade ? fadeInScene(props) : NavigationCardStackStyleInterpolator.forHorizontal(props));
     }
 
     if (typeof(panHandlers) === 'undefined') {

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -43,7 +43,6 @@ const styles = StyleSheet.create({
 
 function fadeInScene(/* NavigationSceneRendererProps */ props) {
   const {
-    layout,
     position,
     scene,
   } = props;
@@ -118,9 +117,9 @@ export default class DefaultRenderer extends Component {
   }
 
   chooseInterpolator(direction, props) {
-    switch(direction) {
+    switch (direction) {
       case 'vertical':
-        return  NavigationCardStackStyleInterpolator.forVertical(props);
+        return NavigationCardStackStyleInterpolator.forVertical(props);
       case 'fade':
         return fadeInScene(props);
       default:

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -50,8 +50,6 @@ function fadeInScene(/* NavigationSceneRendererProps */ props) {
 
   const index = scene.index;
   const inputRange = [index - 1, index, index + 1];
-  const width = layout.initWidth;
-  const height = layout.initHeight;
 
   const opacity = position.interpolate({
     inputRange,
@@ -119,6 +117,17 @@ export default class DefaultRenderer extends Component {
     Actions.focus({ scene });
   }
 
+  chooseInterpolator(direction, props) {
+    switch(direction) {
+      case 'vertical':
+        return  NavigationCardStackStyleInterpolator.forVertical(props);
+      case 'fade':
+        return fadeInScene(props);
+      default:
+        return NavigationCardStackStyleInterpolator.forHorizontal(props);
+    }
+  }
+
   renderCard(/* NavigationSceneRendererProps */ props) {
     const { key, direction, getSceneStyle } = props.scene.navigationState;
     let { panHandlers, animationStyle } = props.scene.navigationState;
@@ -139,12 +148,9 @@ export default class DefaultRenderer extends Component {
     const style = getSceneStyle ? getSceneStyle(props, computedProps) : null;
 
     const isVertical = direction === 'vertical';
-    const isFade = direction === 'fade';
 
     if (typeof(animationStyle) === 'undefined') {
-      animationStyle = (isVertical ?
-        NavigationCardStackStyleInterpolator.forVertical(props) :
-        isFade ? fadeInScene(props) : NavigationCardStackStyleInterpolator.forHorizontal(props));
+      animationStyle = this.chooseInterpolator(direction, props);
     }
 
     if (typeof(panHandlers) === 'undefined') {


### PR DESCRIPTION
This would allow you to use ```direction="fade"``` as another option to vertical when transitioning from one scene to another.  This could be a fix until something like this is added to NavigationExperimental.

I tried to accomplish this without the need for changes to DefaultRenderer by passing in animationStyle, but I couldn't figure out how to access the NavigationSceneRendererProps (location, position, scene) from Example.js, or if it's even possible.