### PR TITLE
Add parent's NavBar style for TabBar component

### DIFF
--- a/src/TabbedView.js
+++ b/src/TabbedView.js
@@ -54,9 +54,10 @@ class TabbedView extends Component {
         return;
       }
       this.renderedSceneKeys[key] = true;
-      item.navigationBarStyle = this.props.navigationState.navigationBarStyle;
-      item.titleStyle = this.props.navigationState.titleStyle;
-      scenes.push(this.renderScene(item, i));
+      const child = item;
+      child.navigationBarStyle = this.props.navigationState.navigationBarStyle;
+      child.titleStyle = this.props.navigationState.titleStyle;
+      scenes.push(this.renderScene(child, i));
     });
     return (
       <View style={this.props.style}>

--- a/src/TabbedView.js
+++ b/src/TabbedView.js
@@ -54,6 +54,8 @@ class TabbedView extends Component {
         return;
       }
       this.renderedSceneKeys[key] = true;
+      item.navigationBarStyle = this.props.navigationState.navigationBarStyle;
+      item.titleStyle = this.props.navigationState.titleStyle;
       scenes.push(this.renderScene(item, i));
     });
     return (


### PR DESCRIPTION
i can't use navigationBarStyle props for set a custom navbar for all tabs.
Example:

```
<Scene
  key="main"
  navigationBarStyle={{ backgroundColor: 'white' }} // <-- This Not Work on tabs
  tabs
  tabBarStyle={styles.tabBarStyle}
  tabBarSelectedItemStyle={styles.tabBarSelectedItemStyle}
>
  <Scene
    key="tab1"
    title="Tab #1"
    icon={TabIcon}
    navigationBarStyle={{ backgroundColor: 'red' }}
    titleStyle={{ color: 'white' }}
    component={TabView}
  />
  <Scene key="tab2" component={TabView} initial title="Tab #2" icon={TabIcon} />
// other tabs
</Scene>
```