### PR TITLE
Removed fontWeight style from NavBar title

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -44,7 +44,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginTop: 10,
     fontSize: 18,
-    fontWeight: '500',
     color: '#0A0A0A',
     position: 'absolute',
     ...Platform.select({


### PR DESCRIPTION
Setting default fontWeight style for NavBar title ignores custom fonts on Android