### PR TITLE
Added optional tabBarIconContainerStyle property to override the style of the icon container view.

### DIFF
--- a/docs/API_CONFIGURATION.md
+++ b/docs/API_CONFIGURATION.md
@@ -50,7 +50,9 @@
 |-----------|--------|---------|--------------------------------------------|
 | tabs| `bool` | false | Defines 'TabBar' scene container, so child scenes will be displayed as 'tabs'. If no `component` is defined, built-in `TabBar` is used as renderer. All child scenes are wrapped into own navbar.
 | tabBarStyle | [`View style`](https://facebook.github.io/react-native/docs/view.html#style) |  | optional style override for the Tabs component |
+| tabBarIconContainerStyle | [`View style`](https://facebook.github.io/react-native/docs/view.html#style) |  | optional style override for the View that contains each tab icon |
 | hideTabBar | `bool` | false | hides tab bar for this scene and any following scenes until explicitly reversed (if built-in TabBar component is used as parent renderer)|
+
 
 ### Navigation Bar
 | Property | Type | Default | Description |

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -16,6 +16,7 @@ export default class extends React.Component {
   static propTypes = {
     tabBarStyle: View.propTypes.style,
     tabBarSelectedItemStyle: View.propTypes.style,
+    tabBarIconContainerStyle: View.propTypes.style,
     tabBarShadowStyle: View.propTypes.style,
     tabSceneStyle: View.propTypes.style,
     tabStyle: View.propTypes.style,

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -60,6 +60,7 @@ class TabBar extends Component {
           <Tabs
             style={state.tabBarStyle}
             selectedIconStyle={state.tabBarSelectedItemStyle}
+            iconStyle={state.tabBarIconContainerStyle}
             onSelect={this.onSelect} {...state}
             selected={state.children[state.index].sceneKey}
           >


### PR DESCRIPTION
Had trouble styling the tab icons the way I wanted, so I exposed the iconStyle property of the TabBar the the scene component, under the name tabBarIconContainerStyle.

Also added it to the documentation.