### PR TITLE
modify renderBackButton, make the back image position better

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -235,6 +235,7 @@ class NavBar extends React.Component {
         onPress={onPress}
       >
         {buttonImage && !childState.hideBackImage &&
+          <View style={{ flex: 1, justifyContent: 'center', alignItems: 'flex-start' }}>
           <Image
             source={buttonImage}
             style={[
@@ -245,6 +246,7 @@ class NavBar extends React.Component {
               childState.leftButtonIconStyle,
             ]}
           />
+          </View>
         }
         {text}
       </TouchableOpacity>


### PR DESCRIPTION
when add custom leftButton, if modify the height and width, the title display not very well. The left image not in center.

e.g.
```
  leftButtonImage ={require('./image/header_left_button.png')}
          leftButtonIconStyle={{resizeMode:"contain", height:50, width:50}}
```
