### PR TITLE
[RFC] add parent and key as prefix to new key

### DIFF
--- a/src/State.js
+++ b/src/State.js
@@ -37,12 +37,12 @@ export function getInitialState(
   props = {}
 ) {
   // eslint-disable-next-line no-unused-vars
-  const { key, style, type, ...parentProps } = props;
+  const { parent, key, style, type, ...parentProps } = props;
   if (!route.children) {
     return {
       ...scenes.rootProps,
       ...route,
-      key: `${position}_${route.sceneKey}`,
+      key: `${parent}_${key}_${position}_${route.sceneKey}`,
       ...parentProps,
       ...getStateFromScenes(route, scenes, props),
     };


### PR DESCRIPTION
Requesting comments and review to make sure this does not break anything.

I am ending up with non-unique keys in my navigationState when using the `clone` feature.  This can result from component `Foo` being pushed into `Tab A`, and then pushed into `Tab B`, and having two `1_Foo` keys in the `navigationState`.

This creates corruption when using `Actions.refresh({key, ...})`.

This change prepends the parent and key, resulting in keys like: `tabA_Foo_1_Foo` instead of `1_Foo`.

I'm not sure if this would affect any other cases outside of `clone`.
