### PR TITLE
throw error when pop action is called on root scene in android.

### DIFF
--- a/docs/ANDROID_BACK. md
+++ b/docs/ANDROID_BACK. md
@@ -1,0 +1,47 @@
+Android back action
+====
+This is an example to handle `back button action` in android.
+
+The reducer will throw an error when the back button is clicked on root scenes. You can catch the error, and handle the back action as you want.
+
+# Example
+
+`main.js`
+```Javascript
+import { BackAndroid } from 'react-native'
+
+backButtonPressedOnceToExit = false;
+
+export default class Main extends React.Component {
+...
+  componentWillMount(){
+    BackAndroid.addEventListener('hardwareBackPress', this.onBackAndroid.bind(this));
+  }
+
+  componentWillMount(){
+    BackAndroid.addEventListener('hardwareBackPress', this.onBackAndroid.bind(this));
+    }
+
+  onBackAndroid() {
+    if(backButtonPressedOnceToExit){
+      BackAndroid.exitApp();
+    }else{
+      try {
+          Actions.pop();
+          return true;
+      } catch (err) {
+        backButtonPressedOnceToExit = true;
+        console.info('push again to exit');
+        setTimeout(function () {
+            backButtonPressedOnceToExit = false;
+        }, 2000);
+        return true;
+      }
+    }
+...
+}
+
+
+
+
+```

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -13,6 +13,7 @@ import * as ActionConst from './ActionConst';
 import { ActionMap } from './Actions';
 import { assert } from './Util';
 import { getInitialState } from './State';
+import { Platform } from 'react-native';
 
 // WARN: it is not working correct. rewrite it.
 function checkPropertiesEqual(action, lastAction) {
@@ -64,6 +65,9 @@ function inject(state, action, props, scenes) {
     case ActionConst.BACK_ACTION: {
       assert(!state.tabs, 'pop() operation cannot be run on tab bar (tabs=true)');
       if (state.index === 0) {
+        if(Platform.OS === 'android'){
+          assert(false, 'pop() action is called on a root scene');
+        }
         return state;
       }
 

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -65,7 +65,7 @@ function inject(state, action, props, scenes) {
     case ActionConst.BACK_ACTION: {
       assert(!state.tabs, 'pop() operation cannot be run on tab bar (tabs=true)');
       if (state.index === 0) {
-        if(Platform.OS === 'android'){
+        if (Platform.OS === 'android') {
           assert(false, 'pop() action is called on a root scene');
         }
         return state;


### PR DESCRIPTION
This change is for handle the back action in android.  In android, when user click the back button, the pop() action is trigger, however,  we want to know the pop is triggered on root scene, to handle the exit app action. 
refer to [Feature Hand Back Key for Android](https://github.com/aksonov/react-native-router-flux/pull/820)