### PR TITLE
add prop for navigation card style

### DIFF
--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -128,7 +128,7 @@ export default class DefaultRenderer extends Component {
   }
 
   renderCard(/* NavigationSceneRendererProps */ props) {
-    const { key, direction, animation, getSceneStyle } = props.scene.navigationState;
+    const { key, direction, animation, getSceneStyle, navigationCardStyle } = props.scene.navigationState;
     let { panHandlers, animationStyle } = props.scene.navigationState;
 
     const state = props.navigationState;
@@ -168,7 +168,7 @@ export default class DefaultRenderer extends Component {
       <NavigationCard
         {...props}
         key={`card_${key}`}
-        style={[animationStyle, style]}
+        style={[animationStyle, style, navigationCardStyle]}
         panHandlers={panHandlers}
         renderScene={this.renderScene}
       />


### PR DESCRIPTION
Adds a prop for adding / changing current styles in the navigation card. This is mainly for shared background images across scenes and solves https://github.com/aksonov/react-native-router-flux/issues/927.

Example:
`<Scene key='home' component={Home} title='Home' navigationCardStyle={{ backgroundColor: 'transparent', shadowColor: 'transparent' }} />
          `