### PR TITLE
fix(navigationState): avoid undefined key for root scenes

### DIFF
--- a/src/State.js
+++ b/src/State.js
@@ -30,6 +30,12 @@ function getStateFromScenes(route, scenes, props) {
   return result;
 }
 
+function getSceneKey(parent, key, position, sceneKey) {
+  return [parent, key, position, sceneKey]
+    .filter(v => typeof(v) !== 'undefined' && v !== null)
+    .join('_');
+}
+
 export function getInitialState(
   route: {string: any},
   scenes: {string: any},
@@ -42,7 +48,7 @@ export function getInitialState(
     return {
       ...scenes.rootProps,
       ...route,
-      key: `${parent}_${key}_${position}_${route.sceneKey}`,
+      key: getSceneKey(parent, key, position, route.sceneKey),
       ...parentProps,
       ...getStateFromScenes(route, scenes, props),
     };


### PR DESCRIPTION
This is one of the issues I've been investigating within my app.
Apparently #911 broke scene key generation when the scene has no parent.

Before:

```javascript
Object {key: "undefined_undefined_0_home_", name: "home", sceneKey: "home_", parent: "home", type: "REACT_NATIVE_ROUTER_FLUX_PUSH"…}
```

After:

```javascript
Object {key: "0_home_", name: "home", sceneKey: "home_", parent: "home", type: "REACT_NATIVE_ROUTER_FLUX_PUSH"…}
```