### PR TITLE
Update tabs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "react-native-experimental-navigation": "0.26.x",
-    "react-native-tabs": "1.0.7",
+    "react-native-tabs": "1.0.9",
     "react-static-container": "1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "react-native-experimental-navigation": "0.26.x",
-    "react-native-tabs": "1.0.9",
+    "react-native-tabs": "^1.0.9",
     "react-static-container": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
pressOpacity prop added for tab icon in 1.0.9 version.

[https://github.com/aksonov/react-native-tabs/commit/f736cf6ee11d1aeb758392807243367d13971c3e](https://github.com/aksonov/react-native-tabs/commit/f736cf6ee11d1aeb758392807243367d13971c3e)