### PR TITLE
Add "Junk Free" production app

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ And then:
 ## Production Apps using react-native-router-flux
 + GuavaPass.com ([iOS](https://itunes.apple.com/en/app/guavapass-one-pass-fitness/id1050491044?l=en&mt=8), Android) - offers convenient access to top classes at boutique fitness studios across Asia.
 + Epic Fail Videos ([iOS](https://itunes.apple.com/us/app/epic-fail-videos-best-fail/id1115219339), [Android](https://play.google.com/store/apps/details?id=com.hazuu.epicfailvideos)) - The best Fail Videos Collection, never miss a laugh with your friends!
++ Junk Free ([iOS](https://itunes.apple.com/us/app/junk-free-by-junk-free-june/id1109940159)) - A simple way to find, share, and save recipes, workouts, and other healthy content with your friends, family and workmates. 
 
 ## Support
 Thanks to all who submitted PRs to 2.x release. If you like the component and want to support it, feel free to donate any amount or help with issues.


### PR DESCRIPTION
Junk Free is the official app for the annual ["Junk Free June" campaign](http://junkfreejune.org) currently run in New Zealand and Australia, which promotes healthy living and raises money for cancer charities. 

We use react-native-router-flux extensively with redux, and found support for tabs in RNRF really great.