### PR TITLE
feat(Actions): modify prototype to get scene props

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -156,20 +156,32 @@ class Actions {
       if (this[el.key]) {
         console.log(`Key ${el.key} is already defined!`);
       }
-      this[el.key] =
-        (props = {}) => {
-          assert(this.callback, 'Actions.callback is not defined!');
-          this.callback({ key: el.key, type: ActionConst.REFRESH, ...filterParam(props) });
-        };
+      const setup = (o) => {
+        const call =
+          (props = {}) => {
+            assert(this.callback, 'Actions.callback is not defined!');
+            this.callback({ key: el.key, type: ActionConst.REFRESH, ...filterParam(props) });
+          };
+        Object.setPrototypeOf(o, Object.getPrototypeOf(call));
+        Object.setPrototypeOf(call, o);
+        return call;
+      };
+      this[key] = setup(staticProps);
     }
     if (this[key]) {
       console.log(`Key ${key} is already defined!`);
     }
-    this[key] =
-      (props = {}) => {
-        assert(this.callback, 'Actions.callback is not defined!');
-        this.callback({ key, type, ...filterParam(props) });
-      };
+    const setup = (o) => {
+      const call =
+        (props = {}) => {
+          assert(this.callback, 'Actions.callback is not defined!');
+          this.callback({ key, type, ...filterParam(props) });
+        };
+      Object.setPrototypeOf(o, Object.getPrototypeOf(call));
+      Object.setPrototypeOf(call, o);
+      return call;
+    };
+    this[key] = setup(staticProps);
     refs[res.key] = res;
 
     return res;


### PR DESCRIPTION
I modified the prototype of `Actions[key]` in order to have access to the scene props. This is very useful in this auth scenario where you'd simple add a propType like `<Scene key="someSceneKey" forbidden={true} />` and have access just with `Actions.someSceneKey.forbidden`, etc

I don't know if prototypes are the best way to go but it was the only one to avoid breaking changes..