### PR TITLE
fix(NavBar): don't render custom BackButton if root nav state

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -205,6 +205,11 @@ class NavBar extends React.Component {
       state.leftButtonStyle,
       childState.leftButtonStyle,
     ];
+
+    if (state.index === 0) {
+      return null;
+    }
+
     if (BackButton) {
       return (
         <BackButton
@@ -222,9 +227,6 @@ class NavBar extends React.Component {
       onPress = onPress.bind(null, state);
     } else {
       onPress = Actions.pop;
-    }
-    if (state.index === 0) {
-      return null;
     }
 
     let text = childState.backTitle ?


### PR DESCRIPTION
Avoid rendering a custom `BackButton` if the default implementation
should avoid rendering, such as when the current scene is the root
scene. Since main `state` isn't being passed to the custom component
we have no way (that I'm aware of) of determining whether it should
actually render a back button.