### PR TITLE
Allow POP and similar actions to refresh the previous scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ import {Actions} from 'react-native-router-flux'
 And then:
 
 * `Actions.ACTION_NAME(PARAMS)` will call the appropriate action and params will be passed to the scene.
-* `Actions.pop()` will pop the current screen. It can also take a param `{popNum: [number]}` that allows to pop multiple screens at once.
+* `Actions.pop()` will pop the current screen. It accepts following optional params:
+  * `{popNum: [number]}` allows to pop multiple screens at once 
+  * `{refresh: {...propsToSetOnPreviousScene}}` allows to refresh the props of the scene that it pops back to
 * `Actions.refresh(PARAMS)` will update the properties of the current screen.
 
 ## Production Apps using react-native-router-flux

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -47,8 +47,13 @@ function resetHistoryStack(child) {
 }
 
 function refreshTopChild(children, refresh) {
-  const topChild = children[children.length - 1];
-  return [...children.slice(0, -1), { ...topChild, ...refresh }];
+  if (refresh) {
+    const topChild = children[children.length - 1];
+    return [...children.slice(0, -1), { ...topChild, ...refresh }];
+  }
+  else {
+    return children;
+  }
 }
 
 function inject(state, action, props, scenes) {

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -46,6 +46,11 @@ function resetHistoryStack(child) {
   );
 }
 
+function refreshTopChild(children, refresh){
+  const topChild = children[children.length - 1];
+  return [...children.slice(0, -1), {...topChild, ...refresh}];
+}
+
 function inject(state, action, props, scenes) {
   const condition = ActionMap[action.type] === ActionConst.REFRESH ? state.key === props.key ||
   state.sceneKey === action.key : state.sceneKey === props.parent;
@@ -75,7 +80,7 @@ function inject(state, action, props, scenes) {
       return {
         ...state,
         index: targetIndex,
-        children: state.children.slice(0, (targetIndex + 1)),
+        children: refreshTopChild(state.children.slice(0, (targetIndex + 1)), action.refresh),
       };
     }
 
@@ -104,7 +109,7 @@ function inject(state, action, props, scenes) {
         ...state,
         index: state.index - popNum,
         from: state.children[state.children.length - popNum],
-        children: state.children.slice(0, -1 * popNum),
+        children: refreshTopChild(state.children.slice(0, -1 * popNum), action.refresh),
       };
     }
     case ActionConst.REFRESH:
@@ -126,7 +131,7 @@ function inject(state, action, props, scenes) {
           ...state,
           index: ind,
           from: state.children[state.index],
-          children: state.children.slice(0, ind + 1),
+          children: refreshTopChild(tate.children.slice(0, ind + 1), action.refresh),
         };
       }
       return {

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -131,7 +131,7 @@ function inject(state, action, props, scenes) {
           ...state,
           index: ind,
           from: state.children[state.index],
-          children: refreshTopChild(tate.children.slice(0, ind + 1), action.refresh),
+          children: refreshTopChild(state.children.slice(0, ind + 1), action.refresh),
         };
       }
       return {

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -46,9 +46,9 @@ function resetHistoryStack(child) {
   );
 }
 
-function refreshTopChild(children, refresh){
+function refreshTopChild(children, refresh) {
   const topChild = children[children.length - 1];
-  return [...children.slice(0, -1), {...topChild, ...refresh}];
+  return [...children.slice(0, -1), { ...topChild, ...refresh }];
 }
 
 function inject(state, action, props, scenes) {

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -51,9 +51,7 @@ function refreshTopChild(children, refresh) {
     const topChild = children[children.length - 1];
     return [...children.slice(0, -1), { ...topChild, ...refresh }];
   }
-  else {
-    return children;
-  }
+  return children;
 }
 
 function inject(state, action, props, scenes) {


### PR DESCRIPTION
I recently saw several questions on stackoverflow and here in issues (#1014, #1008), people were asking how to pass props to previous scene on pop. 
So I think it's a good idea to be able to make calls like `Actions.pop({refresh: propsToPassToPreviousScene})`