### PR TITLE
Add default style to renderLeftButton and renderRightButton

### DIFF
--- a/Example/Example.js
+++ b/Example/Example.js
@@ -28,19 +28,6 @@ import EchoView from './components/EchoView';
 import NavigationDrawer from './components/NavigationDrawer';
 import Button from 'react-native-button';
 
-const Right = () => (
-  <Text
-    style={{
-      width: 80,
-      height: 37,
-      position: 'absolute',
-      bottom: 4,
-      right: 2,
-      padding: 8,
-    }}
-  >Right</Text>
-);
-
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: 'transparent', justifyContent: 'center',
     alignItems: 'center',
@@ -186,7 +173,7 @@ class Example extends Component {
                     key="tab2_1"
                     component={TabView}
                     title="Tab #2_1"
-                    renderRightButton={() => <Right />}
+                    renderRightButton={() => <Text>Right</Text>}
                   />
                   <Scene
                     key="tab2_2"

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -450,14 +450,23 @@ class NavBar extends React.Component {
       selected = selected.children[selected.index];
     }
     const navProps = { ...this.props, ...selected };
-    const renderLeftButton = selected.renderLeftButton ||
-      selected.component.renderLeftButton ||
+
+    const wrapByStyle = (component, wrapStyle) => {
+      if (!component) { return null; }
+      return (props) => <View style={wrapStyle}>{component(props)}</View>;
+    };
+
+    const leftButtonStyle = [styles.leftButton, { alignItems: 'flex-start' }];
+    const rightButtonStyle = [styles.rightButton, { alignItems: 'flex-end' }];
+
+    const renderLeftButton = wrapByStyle(selected.renderLeftButton, leftButtonStyle) ||
+      wrapByStyle(selected.component.renderLeftButton, leftButtonStyle) ||
       this.renderLeftButton;
-    const renderRightButton = selected.renderRightButton ||
-      selected.component.renderRightButton ||
+    const renderRightButton = wrapByStyle(selected.renderRightButton, rightButtonStyle) ||
+      wrapByStyle(selected.component.renderRightButton, rightButtonStyle) ||
       this.renderRightButton;
-    const renderBackButton = selected.renderBackButton ||
-      selected.component.renderBackButton ||
+    const renderBackButton = wrapByStyle(selected.renderBackButton, leftButtonStyle) ||
+      wrapByStyle(selected.component.renderBackButton, leftButtonStyle) ||
       this.renderBackButton;
     const renderTitle = selected.renderTitle ||
       selected.component.renderTitle ||


### PR DESCRIPTION
## Abstract
Added default style to `renderLeftButton` and `renderRightButton` for reduce extra adjustments.

## Detail
`renderLeftButton` and `renderRightButton` provide a method to add a component to navigation-bar. But, If we add component without adjusting style, It will be shown unexpected position. Example is below:

![screenshots_2016-08-14_17_08_25](https://cloud.githubusercontent.com/assets/2082161/17648389/74d38444-6245-11e6-816b-4c4951da2c87.jpg)

So, I added view component that has default style as parent component of these components. Result is below:

![screenshots 2016-08-14 17 05 52](https://cloud.githubusercontent.com/assets/2082161/17648366/7ab12610-6244-11e6-9a13-623079f0a4d3.jpg)


## Related Issue
- #994
