### PR TITLE
Fix for back button not displayed when pushing tabs scene.

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -206,7 +206,7 @@ class NavBar extends React.Component {
       childState.leftButtonStyle,
     ];
 
-    if (state.index === 0) {
+    if (state.index === 0 && (!state.parentIndex || state.parentIndex === 0)) {
       return null;
     }
 

--- a/src/State.js
+++ b/src/State.js
@@ -63,7 +63,8 @@ export function getInitialState(
   });
 
   if (route.tabs) {
-    res.children = route.children.map((r, i) => getInitialState(scenes[r], scenes, i, props));
+    res.children = route.children.map(
+      (r, i) => getInitialState(scenes[r], scenes, i, { ...props, parentIndex: position }));
     res.index = index;
   } else {
     res.children = [getInitialState(scenes[route.children[index]], scenes, 0, props)];


### PR DESCRIPTION
This is a proposed fix for bug https://github.com/aksonov/react-native-router-flux/issues/1092.

When pushing a tabs scene, we add another prop `parentIndex` to the child scene. The navbar can then check the value of it in order to decide, whether to show the back button or not.