### PR TITLE
Allow to force parent tabs to hide when child tabs is added

### DIFF
--- a/docs/API_CONFIGURATION.md
+++ b/docs/API_CONFIGURATION.md
@@ -121,6 +121,7 @@ And every `Scene.type` string literal has a mapped contant in ActionConst, it is
 | tabBarBackgroundImage | [`Image source`](https://facebook.github.io/react-native/docs/image.html#source) |  | optional background image for the Tabs component |
 | tabBarIconContainerStyle | [`View style`](https://facebook.github.io/react-native/docs/view.html#style) |  | optional style override for the View that contains each tab icon |
 | hideTabBar | `bool` | false | hides tab bar for this scene and any following scenes until explicitly reversed (if built-in TabBar component is used as parent renderer)|
+| hideOnChildTabs | `bool` | false | hides tab bar when another `tabs` scene is added to the navigation stack. |
 | pressOpacity | `number` | 0.2 | the opacity when clicking on the tab |
 
 

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -17,6 +17,7 @@ class TabBar extends Component {
     onNavigate: PropTypes.func,
     unmountScenes: PropTypes.bool,
     pressOpacity: PropTypes.number,
+    hideOnChildTabs: PropTypes.bool,
   };
 
   constructor(props, context) {
@@ -49,10 +50,11 @@ class TabBar extends Component {
 
   render() {
     const state = this.props.navigationState;
+    const selected = state.children[state.index];
 
-    const hideTabBar = this.props.unmountScenes
-      ? true
-      : deepestExplicitValueForKey(state, 'hideTabBar');
+    const hideTabBar = this.props.unmountScenes ||
+      deepestExplicitValueForKey(state, 'hideTabBar') ||
+      (this.props.hideOnChildTabs && deepestExplicitValueForKey(selected, 'tabs'));
 
     const contents = (
       <Tabs
@@ -60,7 +62,7 @@ class TabBar extends Component {
         selectedIconStyle={state.tabBarSelectedItemStyle}
         iconStyle={state.tabBarIconContainerStyle}
         onSelect={this.onSelect} {...state}
-        selected={state.children[state.index].sceneKey}
+        selected={selected.sceneKey}
         pressOpacity={this.props.pressOpacity}
       >
         {state.children.filter(el => el.icon || this.props.tabIcon).map(el => {


### PR DESCRIPTION
I have a scenario where I need to go from one tab to another `tabs` scene using push (so the user can also  go back).

If you have a scenario like that, I can imagine two desired behaviors:

1. Both tabbars are displayed among each other (Is quite uncommon though). This way you can always switch tabs on both levels.
2. As soon as the child tabbar is displayed, the parent tabbar is hidden so you always have only one tabbar.

My proposed solution is therefore to introduce another flag I called `hideOnChildTabs`, which - when set to `true` on the parent `tabs` scene -  causes the second behavior. Otherwise the first behavior is used and you have to manually take care of setting your stylesheets so that they are displayed properly on the same screen.

Without this patch, I experienced that the parent tabbar always covered the children's tabbar, which can never be the intended behavior.

I created a little project demonstrating the situation [here](https://github.com/fkoester/react-native-router-flux-nested-tabs).