### PR TITLE
correction to #1057

### DIFF
--- a/Example/__tests__/__snapshots__/Example-test.js.snap
+++ b/Example/__tests__/__snapshots__/Example-test.js.snap
@@ -197,7 +197,7 @@ exports[`Example renders correctly 1`] = `
                           Array [
                             Object {
                               "color": "#007aff",
-                              "fontFamily": ".HelveticaNeueInterface-MediumP4",
+                              "fontFamily": "HelveticaNeue-Medium",
                               "fontSize": 17,
                               "fontWeight": "bold",
                               "textAlign": "center"
@@ -234,7 +234,7 @@ exports[`Example renders correctly 1`] = `
                           Array [
                             Object {
                               "color": "#007aff",
-                              "fontFamily": ".HelveticaNeueInterface-MediumP4",
+                              "fontFamily": "HelveticaNeue-Medium",
                               "fontSize": 17,
                               "fontWeight": "bold",
                               "textAlign": "center"
@@ -271,7 +271,7 @@ exports[`Example renders correctly 1`] = `
                           Array [
                             Object {
                               "color": "#007aff",
-                              "fontFamily": ".HelveticaNeueInterface-MediumP4",
+                              "fontFamily": "HelveticaNeue-Medium",
                               "fontSize": 17,
                               "fontWeight": "bold",
                               "textAlign": "center"
@@ -308,7 +308,7 @@ exports[`Example renders correctly 1`] = `
                           Array [
                             Object {
                               "color": "#007aff",
-                              "fontFamily": ".HelveticaNeueInterface-MediumP4",
+                              "fontFamily": "HelveticaNeue-Medium",
                               "fontSize": 17,
                               "fontWeight": "bold",
                               "textAlign": "center"
@@ -345,7 +345,7 @@ exports[`Example renders correctly 1`] = `
                           Array [
                             Object {
                               "color": "#007aff",
-                              "fontFamily": ".HelveticaNeueInterface-MediumP4",
+                              "fontFamily": "HelveticaNeue-Medium",
                               "fontSize": 17,
                               "fontWeight": "bold",
                               "textAlign": "center"
@@ -382,7 +382,7 @@ exports[`Example renders correctly 1`] = `
                           Array [
                             Object {
                               "color": "#007aff",
-                              "fontFamily": ".HelveticaNeueInterface-MediumP4",
+                              "fontFamily": "HelveticaNeue-Medium",
                               "fontSize": 17,
                               "fontWeight": "bold",
                               "textAlign": "center"
@@ -419,7 +419,7 @@ exports[`Example renders correctly 1`] = `
                           Array [
                             Object {
                               "color": "#007aff",
-                              "fontFamily": ".HelveticaNeueInterface-MediumP4",
+                              "fontFamily": "HelveticaNeue-Medium",
                               "fontSize": 17,
                               "fontWeight": "bold",
                               "textAlign": "center"

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -211,19 +211,26 @@ function inject(state, action, props, scenes) {
       };
     case ActionConst.JUMP:
       assert(state.tabs, `Parent=${state.key} is not tab bar, jump action is not valid`);
-      ind = -1;
-      children = getInitialState(props, scenes, ind, action);
-      children = Array.isArray(children) ? children : [children];
-      children.forEach((child, i) => {
-        if (child.sceneKey === action.key) ind = i;
-      });
+      /* TODO: recursive key search (for sub-tab scenes)*/       
+      ind = state.children.findIndex(el => el.sceneKey === action.key);
+      // variant #1      
+      // get target scene with data passed in Actions.SCENE_KEY(PARAMS)
+      const targetSceneWithData = getInitialState(props, scenes, ind, action);
+      // find same scene in state.children 
+      const targetSceneInState = state.children[ind];
+      // update child with data       
+      state.children[ind] = {...targetSceneInState, ...targetSceneWithData};
 
+      // variant #2 - NOT WORKING
+      // just update target scene in state tree with PARAMS   
+      // state.children[ind] = { ...props, ...state.children[ind] };
+      
       assert(ind !== -1, `Cannot find route with key=${action.key} for parent=${state.key}`);
 
       if (action.unmountScenes) {
         resetHistoryStack(state.children[ind]);
       }
-      return { ...state, index: ind, children };
+      return { ...state, index: ind };
     case ActionConst.REPLACE:
       if (state.children[state.index].sceneKey === action.key) {
         return state;

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -218,7 +218,7 @@ function inject(state, action, props, scenes) {
       const targetSceneWithData = getInitialState(props, scenes, ind, action);
       // find same scene in state.children 
       const targetSceneInState = state.children[ind];
-      // update child with data       
+      // update child scene from state.children with pased data       
       state.children[ind] = {...targetSceneInState, ...targetSceneWithData};
 
       // variant #2 - NOT WORKING

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -76,7 +76,6 @@ function inject(state, action, props, scenes) {
     return state;
   }
   let ind;
-  let children;
 
   switch (ActionMap[action.type]) {
     case ActionConst.POP_TO: {
@@ -209,28 +208,29 @@ function inject(state, action, props, scenes) {
         from: null,
         children: [...state.children, getInitialState(props, scenes, state.index + 1, action)],
       };
-    case ActionConst.JUMP:
+    case ActionConst.JUMP: {
       assert(state.tabs, `Parent=${state.key} is not tab bar, jump action is not valid`);
-      /* TODO: recursive key search (for sub-tab scenes)*/       
+      /* TODO: recursive key search (for sub-tab scenes)*/
       ind = state.children.findIndex(el => el.sceneKey === action.key);
-      // variant #1      
+      // variant #1
       // get target scene with data passed in Actions.SCENE_KEY(PARAMS)
       const targetSceneWithData = getInitialState(props, scenes, ind, action);
-      // find same scene in state.children 
+      // find same scene in state.children
       const targetSceneInState = state.children[ind];
-      // update child scene from state.children with pased data       
-      state.children[ind] = {...targetSceneInState, ...targetSceneWithData};
+      // update child scene from state.children with pased data
+      state.children[ind] = { ...targetSceneInState, ...targetSceneWithData };
 
       // variant #2 - NOT WORKING
-      // just update target scene in state tree with PARAMS   
+      // just update target scene in state tree with PARAMS
       // state.children[ind] = { ...props, ...state.children[ind] };
-      
+
       assert(ind !== -1, `Cannot find route with key=${action.key} for parent=${state.key}`);
 
       if (action.unmountScenes) {
         resetHistoryStack(state.children[ind]);
       }
       return { ...state, index: ind };
+    }
     case ActionConst.REPLACE:
       if (state.children[state.index].sceneKey === action.key) {
         return state;


### PR DESCRIPTION
#1057 allows to push params to tab scenes, but it is breaking sceanes
tree.
Ex: 5 tabs
invoke :Actions.tab5(70)
all tab icons disappear, except tab5 itself.

Here is correction that updates only target scene(appending passed
params only to it)
May be it would repair #1081 too (not tested)