### PR TITLE
Improved RNRFActions interface definition

### DIFF
--- a/docs/OTHER_INFO.md
+++ b/docs/OTHER_INFO.md
@@ -22,7 +22,7 @@ import StatusModal from './components/StatusModal'
       <Scene key="screen1" initial={true} component={Screen1} />
       <Scene key="screen2" component={Screen2} />
     </Scene>
-      <Scene key="statusModal" component={StatusModal} />
+    <Scene key="statusModal" component={StatusModal} />
   </Scene>
 </Router>
 ```


### PR DESCRIPTION
I've improved the RNRFActions interface definition so that the `Actions` object is indexable by key. In code, we can then use `Actions["mySuperAwesomeScene"]()` to make a transition. Better yet, you can create an enum (e.g. `Scenes`) and corresponding `getKey` function which returns scene key based on the enum value, and use it like this: `Actions[getKey(Scenes.Register)]();`