### PR TITLE
Allow styling navbar background image

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -34,10 +34,14 @@ import {
   Text,
   TouchableOpacity,
   View,
+  Dimensions
 } from 'react-native';
 import Actions from './Actions';
 import _drawerImage from './menu_burger.png';
 import _backButtonImage from './back_chevron.png';
+
+const IOS_DEFAULT_HEIGHT = 64;
+const ANDROID_DEFAULT_HEIGHT = 54;
 
 const styles = StyleSheet.create({
   title: {
@@ -67,10 +71,10 @@ const styles = StyleSheet.create({
     top: 0,
     ...Platform.select({
       ios: {
-        height: 64,
+        height: IOS_DEFAULT_HEIGHT,
       },
       android: {
-        height: 54,
+        height: ANDROID_DEFAULT_HEIGHT,
       },
     }),
     right: 0,
@@ -170,6 +174,7 @@ const propTypes = {
   position: PropTypes.object,
   navigationBarStyle: View.propTypes.style,
   navigationBarBackgroundImage: Image.propTypes.source,
+  navigationBarBackgroundImageStyle: Image.propTypes.style,
   renderTitle: PropTypes.any,
 };
 
@@ -488,6 +493,25 @@ class NavBar extends React.Component {
       this.props.renderTitle;
     const navigationBarBackgroundImage = this.props.navigationBarBackgroundImage ||
       state.navigationBarBackgroundImage;
+
+    // by default, we want the background image to stretch over the whole navbar
+    // Note that if you change the overall navbar height, you'll have to change the background height too
+    const navigationBarBackgroundImageStyle = [
+      { ...Platform.select({
+          ios: {
+            height: IOS_DEFAULT_HEIGHT,
+          },
+          android: {
+            height: ANDROID_DEFAULT_HEIGHT,
+          },
+        }),
+        width: Dimensions.get('window').width
+      },
+      this.props.navigationBarBackgroundImageStyle ||
+      state.navigationBarBackgroundImageStyle ||
+      selected.navigationBarBackgroundImageStyle ||
+      {}];
+
     const contents = (
       <View>
         {renderTitle ? renderTitle(navProps) : state.children.map(this.renderTitle, this)}
@@ -505,7 +529,7 @@ class NavBar extends React.Component {
         ]}
       >
         {navigationBarBackgroundImage ? (
-          <Image source={navigationBarBackgroundImage}>
+          <Image source={navigationBarBackgroundImage} style={navigationBarBackgroundImageStyle}>
             {contents}
           </Image>
         ) : contents}


### PR DESCRIPTION
Currently, when you want to specify a background image for the navbar, it is impossible to pass styles to the image. This makes setting a custom width and height impossible unless you are using an image from a resource on the native side. This is unfortunate, since it is by far easiest to include images using a `require` statement, but without being able to style the image afterwards it is impossible to make it stretch the whole navbar.

This PR:
- allows you to set `navigationBarBackgroundImageStyle` as a prop that gets passed along into the `Image` component rendering the background image
- sets the default image style to full navbar width and height (assumed `64` on iOS and `54` on Android). Note that the background image also runs under the iOS status bar.

**Usage**: set `navigationBarBackgroundImage={require('./image.png')}` to set the background image, which automatically fully covers the navbar.

Tested on iOS 9 and 10, **not on Android**. Perhaps you should hold off on merging until some testing can be done on Android.