### PR TITLE
Fix the style of the NavBar content wrapper and its customizable children

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -154,6 +154,7 @@ const propTypes = {
   wrapBy: PropTypes.any,
   component: PropTypes.any,
   backButtonTextStyle: Text.propTypes.style,
+  rightButtonStyle: View.propTypes.style,
   leftButtonStyle: View.propTypes.style,
   leftButtonIconStyle: Image.propTypes.style,
   getTitle: PropTypes.func,

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -483,7 +483,7 @@ class NavBar extends React.Component {
     const navigationBarBackgroundImage = this.props.navigationBarBackgroundImage ||
       state.navigationBarBackgroundImage;
     const contents = (
-      <View>
+      <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'center' }}>
         {renderTitle ? renderTitle(navProps) : state.children.map(this.renderTitle, this)}
         {renderBackButton(navProps) || renderLeftButton(navProps)}
         {renderRightButton(navProps)}

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -465,8 +465,20 @@ class NavBar extends React.Component {
       return props => <View style={wrapStyle}>{component(props)}</View>;
     };
 
-    const leftButtonStyle = [styles.leftButton, { alignItems: 'flex-start' }];
-    const rightButtonStyle = [styles.rightButton, { alignItems: 'flex-end' }];
+    const leftButtonStyle = [
+      styles.leftButton,
+      { alignItems: 'flex-start' },
+      this.props.leftButtonStyle,
+      state.leftButtonStyle,
+      selected.leftButtonStyle,
+    ];
+    const rightButtonStyle = [
+      styles.rightButton,
+      { alignItems: 'flex-end' },
+      this.props.rightButtonStyle,
+      state.rightButtonStyle,
+      selected.rightButtonStyle,
+    ];
 
     const renderLeftButton = wrapByStyle(selected.renderLeftButton, leftButtonStyle) ||
       wrapByStyle(selected.component.renderLeftButton, leftButtonStyle) ||

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -482,12 +482,15 @@ class NavBar extends React.Component {
 
     const renderLeftButton = wrapByStyle(selected.renderLeftButton, leftButtonStyle) ||
       wrapByStyle(selected.component.renderLeftButton, leftButtonStyle) ||
+      wrapByStyle(state.renderLeftButton, leftButtonStyle) ||
       this.renderLeftButton;
     const renderRightButton = wrapByStyle(selected.renderRightButton, rightButtonStyle) ||
       wrapByStyle(selected.component.renderRightButton, rightButtonStyle) ||
+      wrapByStyle(state.renderRightButton, rightButtonStyle) ||
       this.renderRightButton;
     const renderBackButton = wrapByStyle(selected.renderBackButton, leftButtonStyle) ||
       wrapByStyle(selected.component.renderBackButton, leftButtonStyle) ||
+      wrapByStyle(state.renderBackButton, leftButtonStyle) ||
       this.renderBackButton;
     const renderTitle = selected.renderTitle ||
       selected.component.renderTitle ||


### PR DESCRIPTION
Currently, the content of the NavBar is wrapped by `View` so you cannot style the components in it with relative position. To fix this, the default style for the wrapper has changed, and customized styles are also applied to cutomized components. With this PR, you can use `render*Button` prop with the root scene.
