### PR TITLE
Fix bug when specifying only tabIcon for TabBar

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -56,6 +56,13 @@ class TabBar extends Component {
       deepestExplicitValueForKey(state, 'hideTabBar') ||
       (this.props.hideOnChildTabs && deepestExplicitValueForKey(selected, 'tabs'));
 
+    const icons = state.children
+      .filter(el => el.icon || this.props.tabIcon)
+      .map(el => {
+        const Icon = el.icon || this.props.tabIcon;
+        return <Icon {...this.props} {...el} />;
+      });
+
     const contents = (
       <Tabs
         style={state.tabBarStyle}
@@ -65,12 +72,10 @@ class TabBar extends Component {
         selected={selected.sceneKey}
         pressOpacity={this.props.pressOpacity}
       >
-        {state.children.filter(el => el.icon || this.props.tabIcon).map(el => {
-          const Icon = el.icon || this.props.tabIcon;
-          return <Icon {...this.props} {...el} />;
-        })}
+        {icons}
       </Tabs>
     );
+
     return (
       <View
         style={{ flex: 1 }}
@@ -80,7 +85,7 @@ class TabBar extends Component {
           style={{ flex: 1 }}
           renderScene={this.renderScene}
         />
-        {!hideTabBar && state.children.filter(el => el.icon).length > 0 &&
+        {!hideTabBar && icons.length > 0 &&
           (state.tabBarBackgroundImage ? (
             <Image source={state.tabBarBackgroundImage}>
               {contents}


### PR DESCRIPTION
Currently, TabBar isn't rendered when specifying only `tabIcon` without any `icon` for the child scenes.
As far as I looked over the code, I found out this bug was caused by the following one.

```js
state.children.filter(el => el.icon).length > 0
```
ref. https://github.com/aksonov/react-native-router-flux/blob/2b09f47740bb0f5829e8419d9ba6622aef20c42c/src/TabBar.js#L83

I think it is used for checking whether `Tabs` component has one or more `Icon` components.
However, actually it returns `false` In the above-mentioned case.

This PR fixes it.