### PR TITLE
add type support for panHandlers={null} in Scene

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -202,6 +202,8 @@ declare namespace RNRF {
      * optional wrappert
      */
     wrapBy?: ()=>any,
+      
+    panHandlers?: null | (()=>any)
   }
 
   /**


### PR DESCRIPTION
This is very convenient to prevent the user from swiping a scene manually.