### PR TITLE
Apply user styles on left/right NavBar buttons rendered by user

### DIFF
--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -465,8 +465,8 @@ class NavBar extends React.Component {
       return props => <View style={wrapStyle}>{component(props)}</View>;
     };
 
-    const leftButtonStyle = [styles.leftButton, { alignItems: 'flex-start' }, selected.leftButtonStyle, state.leftButtonStyle];
-    const rightButtonStyle = [styles.rightButton, { alignItems: 'flex-end' }, selected.rightButtonStyle, state.rightButtonStyle];
+    const leftButtonStyle = [styles.leftButton, { alignItems: 'flex-start' }, state.leftButtonStyle, selected.leftButtonStyle];
+    const rightButtonStyle = [styles.rightButton, { alignItems: 'flex-end' }, state.rightButtonStyle, selected.rightButtonStyle];
 
     const renderLeftButton = wrapByStyle(selected.renderLeftButton, leftButtonStyle) ||
       wrapByStyle(selected.component.renderLeftButton, leftButtonStyle) ||

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -465,8 +465,8 @@ class NavBar extends React.Component {
       return props => <View style={wrapStyle}>{component(props)}</View>;
     };
 
-    const leftButtonStyle = [styles.leftButton, selected.leftButtonStyle, state.leftButtonStyle, { alignItems: 'flex-start' }];
-    const rightButtonStyle = [styles.rightButton, selected.rightButtonStyle, state.rightButtonStyle, { alignItems: 'flex-end' }];
+    const leftButtonStyle = [styles.leftButton, { alignItems: 'flex-start' }, selected.leftButtonStyle, state.leftButtonStyle];
+    const rightButtonStyle = [styles.rightButton, { alignItems: 'flex-end' }, selected.rightButtonStyle, state.rightButtonStyle];
 
     const renderLeftButton = wrapByStyle(selected.renderLeftButton, leftButtonStyle) ||
       wrapByStyle(selected.component.renderLeftButton, leftButtonStyle) ||

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -465,8 +465,8 @@ class NavBar extends React.Component {
       return props => <View style={wrapStyle}>{component(props)}</View>;
     };
 
-    const leftButtonStyle = [styles.leftButton, { alignItems: 'flex-start' }];
-    const rightButtonStyle = [styles.rightButton, { alignItems: 'flex-end' }];
+    const leftButtonStyle = [styles.leftButton, selected.leftButtonStyle, state.leftButtonStyle, { alignItems: 'flex-start' }];
+    const rightButtonStyle = [styles.rightButton, selected.rightButtonStyle, state.rightButtonStyle, { alignItems: 'flex-end' }];
 
     const renderLeftButton = wrapByStyle(selected.renderLeftButton, leftButtonStyle) ||
       wrapByStyle(selected.component.renderLeftButton, leftButtonStyle) ||


### PR DESCRIPTION
The default behaviour of **\<NavBar>** when renderRightButton/renderLeftButton is used is to wrap the returned component in a **\<View>**. This **\<View>** has only the default styles of **\<NavBar>** and styles specified by user were missing. Now wrappers of custom rendered buttons can be styled too.