### PR TITLE
Add Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: node_js
+node_js:
+  - "6"
+os:
+  - osx
+cache:
+  - yarn
+  - directories:
+    - "$TRAVIS_BUILD_DIR/node_modules"
+    - "$TRAVIS_BUILD_DIR/Example/node_modules"
+notifications:
+  email: false
+branches:
+  only:
+    - master
+env:
+  matrix:
+    - TEST_SUITE=eslint CACHE_NAME=eslint
+    - TEST_SUITE=lib-test CACHE_NAME=lib-test
+    - TEST_SUITE=example-jest CACHE_NAME=example-jest
+before_install:
+  - export YARN_GPG=no
+install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - if [ $TEST_SUITE = example-jest ]; then cd Example && yarn && cd ..; fi
+  - if [ $TEST_SUITE = eslint ] || [ $TEST_SUITE = lib-test ]; then yarn; fi
+before_script:
+  - if [ $TEST_SUITE = example-jest ]; then rm -rf Example/node_modules/react-native-router-flux/node_modules; fi
+  - if [ $TEST_SUITE = example-jest ]; then rm -rf Example/node_modules/react-native-router-flux/Example; fi
+  - if [ $TEST_SUITE = example-jest ]; then cp -r src/ Example/node_modules/react-native-router-flux/src/; fi
+script:
+  - if [ $TEST_SUITE = eslint ]; then node node_modules/eslint/bin/eslint index.js src/ test/; fi
+  - if [ $TEST_SUITE = lib-test ]; then yarn test; fi
+  - if [ $TEST_SUITE = example-jest ]; then cd Example && yarn run jest && cd ..; fi
+before_cache:
+  - if [ $TEST_SUITE = example-jest ]; then rm -rf Example/node_modules/react-native-router-flux/src; fi


### PR DESCRIPTION
This PR is to setup the Travis CI. I have tested the config file on my forked repo.

The CI will contain three parts as before:
- eslint against `src/` and `test/`
- tests for `RNRF`
- jest for `Example`

I only enable the CI for `master` branch for now, but we can enable more branches later if we need to.

@aksonov This is just a configuration file, you need to activate this project on [Travis CI](https://travis-ci.org/) since I don't have the permission. Also you may want to enable `Build only if .travis.yml is present` and  disable `Build pushes` in `settings panel`.

Before merge this PR, please merge #1521 first, it fixes the eslint errors exist in current `master` branch, otherwise the CI will always fail.