### PR TITLE
Add NavBar#navigationBarBackgroundImageStyle

### DIFF
--- a/docs/API_CONFIGURATION.md
+++ b/docs/API_CONFIGURATION.md
@@ -131,6 +131,7 @@ And every `Scene.type` string literal has a mapped constant in ActionConst, it i
 | hideNavBar | `bool` | false | hides the navigation bar for this scene and any following scenes until explicitly reversed |
 | navigationBarStyle | [`View style`](https://facebook.github.io/react-native/docs/view.html#style) |  | optional style override for the navigation bar |
 | navigationBarBackgroundImage | [`Image source`](https://facebook.github.io/react-native/docs/image.html#source) |  | optional background image for the navigation bar |
+| navigationBarBackgroundImageStyle | [`Image style`](https://facebook.github.io/react-native/docs/image.html#style) |  | optional custom style for the background image for the navigation bar |
 | navBar | `React.Component` | | optional custom NavBar for the scene. Check built-in NavBar of the component for reference |
 | drawerImage | [`Image source`](https://facebook.github.io/react-native/docs/image.html#source) | `require('./menu_burger.png')` | Simple way to override the drawerImage in the navBar |
 

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -164,6 +164,7 @@ const propTypes = {
   position: PropTypes.object,
   navigationBarStyle: View.propTypes.style,
   navigationBarBackgroundImage: Image.propTypes.source,
+  navigationBarBackgroundImageStyle: Image.propTypes.style,
   renderTitle: PropTypes.any,
 };
 
@@ -499,7 +500,7 @@ class NavBar extends React.Component {
         ]}
       >
         {navigationBarBackgroundImage ? (
-          <Image source={navigationBarBackgroundImage}>
+          <Image style={this.props.navigationBarBackgroundImageStyle} source={navigationBarBackgroundImage}>
             {contents}
           </Image>
         ) : contents}


### PR DESCRIPTION
In order to implement a NavBar that looks like this:

![screen shot 2017-02-02 at 19 30 32](https://cloud.githubusercontent.com/assets/288569/22564917/323b01f0-e97e-11e6-844e-12c53027beaa.png)

.. I needed control over the style of the `navigationBarBackgroundImage`. 

This adds a new prop to achieve this.

For the example above I used:

```
navigationBarBackgroundImageStyle={{
  resizeMode: 'stretch',
  width: Dimensions.get('window').width,
  height: 73,
}}
```

Documentation updated.