### PR TITLE
add `tabBarBackgroundImageStyle` prop

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -82,7 +82,7 @@ class TabBar extends Component {
         />
         {!hideTabBar && state.children.filter(el => el.icon).length > 0 &&
           (state.tabBarBackgroundImage ? (
-            <Image source={state.tabBarBackgroundImage}>
+            <Image source={state.tabBarBackgroundImage} style={state.tabBarBackgroundImageStyle}>
               {contents}
             </Image>
           ) : contents)


### PR DESCRIPTION
To change `width` and `height` when using [static image resources](https://facebook.github.io/react-native/docs/images.html#static-image-resources)

> Note that image sources required this way include size (width, height) info for the Image. If you need to scale the image dynamically (i.e. via flex), you may need to manually set { width: undefined, height: undefined } on the style attribute.

```js
<Scene
  key="tabbar"
  tabs={true}
  tabBarBackgroundImage={require('someimage.png')}
  tabBarBackgroundImageStyle={{width: undefined, height: undefined}}
>
  ...
</Scene>
```