### PR TITLE
Fix Android pop error.

### DIFF
--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -120,7 +120,6 @@ function inject(state, action, props, scenes) {
       if (state.index === 0) {
         return state;
       }
-      
       return {
         ...state,
         index: state.index - 1,

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -9,7 +9,6 @@
 
 /* eslint-disable no-param-reassign */
 
-import { Platform } from 'react-native';
 import * as ActionConst from './ActionConst';
 import { ActionMap } from './Actions';
 import { assert } from './Util';
@@ -118,10 +117,6 @@ function inject(state, action, props, scenes) {
       };
     }
     case ActionConst.ANDROID_BACK: {
-      if (Platform.OS === 'android') {
-        assert(state.index > 0, 'You are already in the root scene.');
-      }
-
       return {
         ...state,
         index: state.index - 1,

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -117,6 +117,10 @@ function inject(state, action, props, scenes) {
       };
     }
     case ActionConst.ANDROID_BACK: {
+      if (state.index === 0) {
+        return state;
+      }
+      
       return {
         ...state,
         index: state.index - 1,


### PR DESCRIPTION
Fix for Android pop error. Same changes as https://github.com/aksonov/react-native-router-flux/pull/1580 but with eslint passing. This fix is to make it align with the behaviour from IOS, as in if you go back it will not throw an error if you are in the root scene.

Original issue https://github.com/aksonov/react-native-router-flux/issues/1578