### PR TITLE
Add selection view to show below navigationBarTitleImage

### DIFF
--- a/docs/API_CONFIGURATION.md
+++ b/docs/API_CONFIGURATION.md
@@ -131,6 +131,9 @@ And every `Scene.type` string literal has a mapped constant in ActionConst, it i
 | hideNavBar | `bool` | false | hides the navigation bar for this scene and any following scenes until explicitly reversed |
 | navigationBarStyle | [`View style`](https://facebook.github.io/react-native/docs/view.html#style) |  | optional style override for the navigation bar |
 | navigationBarBackgroundImage | [`Image source`](https://facebook.github.io/react-native/docs/image.html#source) |  | optional background image for the navigation bar |
+| navigationBarBackgroundImageStyle | [`Image style`](https://facebook.github.io/react-native/docs/image.html#style) |  | optional style override for the navigation bar background image |
+| navigationBarTitleImage | [`Image source`](https://facebook.github.io/react-native/docs/image.html#source) |  | optional image instead of text title for the navigation bar |
+| navigationBarTitleImageStyle | [`Image style`](https://facebook.github.io/react-native/docs/image.html#style) |  | optional style override for the navigation bar title image |
 | navBar | `React.Component` | | optional custom NavBar for the scene. Check built-in NavBar of the component for reference |
 | drawerImage | [`Image source`](https://facebook.github.io/react-native/docs/image.html#source) | `require('./menu_burger.png')` | Simple way to override the drawerImage in the navBar |
 

--- a/docs/API_CONFIGURATION.md
+++ b/docs/API_CONFIGURATION.md
@@ -134,6 +134,8 @@ And every `Scene.type` string literal has a mapped constant in ActionConst, it i
 | navigationBarBackgroundImageStyle | [`Image style`](https://facebook.github.io/react-native/docs/image.html#style) |  | optional style override for the navigation bar background image |
 | navigationBarTitleImage | [`Image source`](https://facebook.github.io/react-native/docs/image.html#source) |  | optional image instead of text title for the navigation bar |
 | navigationBarTitleImageStyle | [`Image style`](https://facebook.github.io/react-native/docs/image.html#style) |  | optional style override for the navigation bar title image |
+| navigationBarShowImageSelection | `bool` | false | hides the selection line inside navigation bar when using navigationBarTitleImage |
+| navigationBarSelecionStyle | [`View style`](https://facebook.github.io/react-native/docs/view.html#style) |  | optional style to add a selection line below navigationBarTitleImage |
 | navBar | `React.Component` | | optional custom NavBar for the scene. Check built-in NavBar of the component for reference |
 | drawerImage | [`Image source`](https://facebook.github.io/react-native/docs/image.html#source) | `require('./menu_burger.png')` | Simple way to override the drawerImage in the navBar |
 

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
   },
   titleImage: {
     width: 180,
-    alignSelf: 'center'
+    alignSelf: 'center',
   },
   titleWrapper: {
     marginTop: 10,
@@ -461,9 +461,9 @@ class NavBar extends React.Component {
 
   renderImageTitle() {
     const navigationBarTitleImage = this.props.navigationBarTitleImage ||
-      state.navigationBarTitleImage;
+      this.state.navigationBarTitleImage;
     const navigationBarTitleImageStyle = this.props.navigationBarTitleImageStyle ||
-        state.navigationBarTitleImageStyle;
+        this.state.navigationBarTitleImageStyle;
     return (
       <Animated.View
         style={[
@@ -471,10 +471,12 @@ class NavBar extends React.Component {
           this.props.titleWrapperStyle,
         ]}
       >
-        <Animated.Image style={[styles.titleImage, navigationBarTitleImageStyle]} source={navigationBarTitleImage}>
-        </Animated.Image>
+        <Animated.Image
+          style={[styles.titleImage, navigationBarTitleImageStyle]}
+          source={navigationBarTitleImage}
+        />
       </Animated.View>
-    )
+    );
   }
 
   render() {
@@ -512,9 +514,16 @@ class NavBar extends React.Component {
       state.navigationBarBackgroundImageStyle;
     const navigationBarTitleImage = this.props.navigationBarTitleImage ||
       state.navigationBarTitleImage;
+    let imageOrTitle = null;
+    if (navigationBarTitleImage) {
+      imageOrTitle = this.renderImageTitle();
+    } else {
+      imageOrTitle = renderTitle ? renderTitle(navProps)
+      : state.children.map(this.renderTitle, this);
+    }
     const contents = (
       <View>
-        {navigationBarTitleImage ? this.renderImageTitle() : (renderTitle ? renderTitle(navProps) : state.children.map(this.renderTitle, this))}
+        {imageOrTitle}
         {renderBackButton(navProps) || renderLeftButton(navProps)}
         {renderRightButton(navProps)}
       </View>

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -171,6 +171,8 @@ const propTypes = {
   navigationBarBackgroundImageStyle: Image.propTypes.style,
   navigationBarTitleImage: Image.propTypes.source,
   navigationBarTitleImageStyle: Image.propTypes.style,
+  navigationBarShowImageSelection: PropTypes.bool,
+  navigationBarSelecionStyle: View.propTypes.style,
   renderTitle: PropTypes.any,
 };
 
@@ -463,7 +465,11 @@ class NavBar extends React.Component {
     const navigationBarTitleImage = this.props.navigationBarTitleImage ||
       this.state.navigationBarTitleImage;
     const navigationBarTitleImageStyle = this.props.navigationBarTitleImageStyle ||
-        this.state.navigationBarTitleImageStyle;
+      this.state.navigationBarTitleImageStyle;
+    const navigationBarShowImageSelection = this.props.navigationBarShowImageSelection ||
+      this.state.navigationBarShowImageSelection;
+    const navigationBarSelecionStyle = this.props.navigationBarSelecionStyle ||
+      this.state.navigationBarSelecionStyle;
     return (
       <Animated.View
         style={[
@@ -475,6 +481,7 @@ class NavBar extends React.Component {
           style={[styles.titleImage, navigationBarTitleImageStyle]}
           source={navigationBarTitleImage}
         />
+        {navigationBarShowImageSelection && <Animated.View style={navigationBarSelecionStyle} />}
       </Animated.View>
     );
   }

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -483,6 +483,8 @@ class NavBar extends React.Component {
       this.props.renderTitle;
     const navigationBarBackgroundImage = this.props.navigationBarBackgroundImage ||
       state.navigationBarBackgroundImage;
+    const navigationBarBackgroundImageStyle = this.props.navigationBarBackgroundImageStyle ||
+      state.navigationBarBackgroundImageStyle;
     const contents = (
       <View>
         {renderTitle ? renderTitle(navProps) : state.children.map(this.renderTitle, this)}

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -47,6 +47,10 @@ const styles = StyleSheet.create({
     width: 180,
     alignSelf: 'center',
   },
+  titleImage: {
+    width: 180,
+    alignSelf: 'center'
+  },
   titleWrapper: {
     marginTop: 10,
     position: 'absolute',
@@ -165,6 +169,8 @@ const propTypes = {
   navigationBarStyle: View.propTypes.style,
   navigationBarBackgroundImage: Image.propTypes.source,
   navigationBarBackgroundImageStyle: Image.propTypes.style,
+  navigationBarTitleImage: Image.propTypes.source,
+  navigationBarTitleImageStyle: Image.propTypes.style,
   renderTitle: PropTypes.any,
 };
 
@@ -187,6 +193,7 @@ class NavBar extends React.Component {
     this.renderBackButton = this.renderBackButton.bind(this);
     this.renderLeftButton = this.renderLeftButton.bind(this);
     this.renderTitle = this.renderTitle.bind(this);
+    this.renderImageTitle = this.renderImageTitle.bind(this);
   }
 
   renderBackButton() {
@@ -452,6 +459,24 @@ class NavBar extends React.Component {
     );
   }
 
+  renderImageTitle() {
+    const navigationBarTitleImage = this.props.navigationBarTitleImage ||
+      state.navigationBarTitleImage;
+    const navigationBarTitleImageStyle = this.props.navigationBarTitleImageStyle ||
+        state.navigationBarTitleImageStyle;
+    return (
+      <Animated.View
+        style={[
+          styles.titleWrapper,
+          this.props.titleWrapperStyle,
+        ]}
+      >
+        <Animated.Image style={[styles.titleImage, navigationBarTitleImageStyle]} source={navigationBarTitleImage}>
+        </Animated.Image>
+      </Animated.View>
+    )
+  }
+
   render() {
     let state = this.props.navigationState;
     let selected = state.children[state.index];
@@ -485,9 +510,11 @@ class NavBar extends React.Component {
       state.navigationBarBackgroundImage;
     const navigationBarBackgroundImageStyle = this.props.navigationBarBackgroundImageStyle ||
       state.navigationBarBackgroundImageStyle;
+    const navigationBarTitleImage = this.props.navigationBarTitleImage ||
+      state.navigationBarTitleImage;
     const contents = (
       <View>
-        {renderTitle ? renderTitle(navProps) : state.children.map(this.renderTitle, this)}
+        {navigationBarTitleImage ? this.renderImageTitle() : (renderTitle ? renderTitle(navProps) : state.children.map(this.renderTitle, this))}
         {renderBackButton(navProps) || renderLeftButton(navProps)}
         {renderRightButton(navProps)}
       </View>
@@ -502,7 +529,7 @@ class NavBar extends React.Component {
         ]}
       >
         {navigationBarBackgroundImage ? (
-          <Image style={...navigationBarBackgroundImageStyle} source={navigationBarBackgroundImage}>
+          <Image style={navigationBarBackgroundImageStyle} source={navigationBarBackgroundImage}>
             {contents}
           </Image>
         ) : contents}

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -164,6 +164,7 @@ const propTypes = {
   position: PropTypes.object,
   navigationBarStyle: View.propTypes.style,
   navigationBarBackgroundImage: Image.propTypes.source,
+  navigationBarBackgroundImageStyle: Image.propTypes.style,
   renderTitle: PropTypes.any,
 };
 
@@ -499,7 +500,7 @@ class NavBar extends React.Component {
         ]}
       >
         {navigationBarBackgroundImage ? (
-          <Image source={navigationBarBackgroundImage}>
+          <Image style={...navigationBarBackgroundImageStyle} source={navigationBarBackgroundImage}>
             {contents}
           </Image>
         ) : contents}

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -467,9 +467,9 @@ class NavBar extends React.Component {
     const navigationBarTitleImageStyle = this.props.navigationBarTitleImageStyle ||
       this.state.navigationBarTitleImageStyle;
     const navigationBarShowImageSelection = this.props.navigationBarShowImageSelection ||
-      this.state.navigationBarShowImageSelection;
+      this.state.navigationBarShowImageSelection || {};
     const navigationBarSelecionStyle = this.props.navigationBarSelecionStyle ||
-      this.state.navigationBarSelecionStyle;
+      this.state.navigationBarSelecionStyle || false;
     return (
       <Animated.View
         style={[


### PR DESCRIPTION
Like instagram does, it adds a selection to the current image. 

With these new props you can show a view as a line selection below the navigationBarTitleImage

![screen shot 2017-04-03 at 1 01 57 pm](https://cloud.githubusercontent.com/assets/5097194/24618589/ec87f900-186d-11e7-8ab9-4aecc3992c5f.png)
![screen shot 2017-04-03 at 12 08 27 pm](https://cloud.githubusercontent.com/assets/5097194/24618591/ec892c94-186d-11e7-9546-42839e854667.png)
![screen shot 2017-04-03 at 12 08 01 pm](https://cloud.githubusercontent.com/assets/5097194/24618590/ec88eb4e-186d-11e7-8545-4ea6c392db5c.png)

Adding a line below is very simple, on navigationBarSelectionStyle just add:

```
<Scene 
  navigationBarShowImageSelection={true}
  navigationBarSelectionStyle={{backgroundColor: '#000', alignSelf: 'center', height: 3, width: 110}}
/>
```