### PR TITLE
Maintain tab parentIndex when jumping tabs

### DIFF
--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -230,7 +230,7 @@ function inject(state, action, props, scenes) {
         props,
         scenes,
         state.index,
-        action,
+        { ...action, parentIndex: state.children[ind].parentIndex },
       );
 
       return { ...state, index: ind };

--- a/test/Reducer.test.js
+++ b/test/Reducer.test.js
@@ -18,6 +18,7 @@ export default function getCurrent(state) {
 const id = 0;
 const guid = () => id + 1;
 const noop = () => {};
+const component = React.Component;
 const scenesData = (
   <Scene
     key="root"
@@ -118,10 +119,20 @@ describe('handling actions', () => {
 
   beforeEach(() => {
     const scene = (
-      <Scene key="root" component={noop}>
+      <Scene key="root" component={component}>
         <Scene key="main" tabs>
-          <Scene key="hello" component={noop} initial />
-          <Scene key="world" component={noop} />
+          <Scene key="hello" component={component} initial />
+          <Scene key="world" component={component}>
+            <Scene key="world_content" component={component} />
+            <Scene key="maps" component={component}>
+              <Scene key="maps_content" component={component} />
+              <Scene key="map_tabs" component={component} tabs={true}>
+                <Scene key="map_tab_1" component={component} />
+                <Scene key="map_tab_2" component={component} />
+                <Scene key="map_tab_3" component={component} />
+              </Scene>
+            </Scene>
+          </Scene>
         </Scene>
       </Scene>
     );
@@ -148,9 +159,28 @@ describe('handling actions', () => {
   it('switches to a correct tab on JUMP', () => {
     Actions.main();
     Actions.hello();
-
     expect(current.key).to.eq('hello_0_hello_');
   });
+
+  it('maintains scene parentIndex when switching tabs', () => {
+    Actions.world();
+    expect(current.key).to.eq('world_0_world_content');
+
+    Actions.maps({ type: 'push' });
+    expect(current.key).to.eq('maps_0_maps_content');
+
+    Actions.map_tabs();
+    expect(current.key).to.eq('map_tabs_0_map_tab_1_');
+    expect(current.parentIndex).to.eq(1);
+
+    Actions.map_tab_2();
+    expect(current.key).to.eq('map_tab_2_0_map_tab_2_');
+    expect(current.parentIndex).to.eq(1);
+
+    Actions.map_tab_3();
+    expect(current.key).to.eq('map_tab_3_0_map_tab_3_');
+    expect(current.parentIndex).to.eq(1);
+  })
 });
 
 describe('passing props from actions', () => {

--- a/test/Reducer.test.js
+++ b/test/Reducer.test.js
@@ -126,7 +126,7 @@ describe('handling actions', () => {
             <Scene key="world_content" component={component} />
             <Scene key="maps" component={component}>
               <Scene key="maps_content" component={component} />
-              <Scene key="map_tabs" component={component} tabs={true}>
+              <Scene key="map_tabs" component={component} tabs>
                 <Scene key="map_tab_1" component={component} />
                 <Scene key="map_tab_2" component={component} />
                 <Scene key="map_tab_3" component={component} />
@@ -180,7 +180,7 @@ describe('handling actions', () => {
     Actions.map_tab_3();
     expect(current.key).to.eq('map_tab_3_0_map_tab_3_');
     expect(current.parentIndex).to.eq(1);
-  })
+  });
 });
 
 describe('passing props from actions', () => {


### PR DESCRIPTION
Hi @aksonov & all, this pull request fixes issue #1758.

I'm new to RNRF, so I don't know the full history, but: this functionality appears to not exist in 3.35 and was introduced in 3.36. I believe this regression was introduced by 6526529 as this functionality was broken 3.37+. 

When performing a JUMP action, we were replace the state of the `tabs` route child, thus replacing the special `parentIndex` attribute that is introduced to the children when a `tabs` route is PUSHed.

The observed user behavior is that the navigation bar's back button will disappear after switching tabs on a PUSHed `tabs` route.

Please let me know if you think there is test coverage missing, or would prefer a different implementation. The way I fixed it feels odd, as it seems to be mixing concerns of the `Reducer` and the `State` functionality.

Thanks,
Dan