### PR TITLE
removed react-native-dependency as it will result in duplicate-module…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react": "^15.4.2",
     "react-addons-pure-render-mixin": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-native": "^0.41.2",
     "react-native-experimental-navigation": "0.26.x",
     "react-native-tabs": "^1.0.9",
     "react-static-container": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "jest": "19.0.1",
     "react-test-renderer": "15.4.2",
     "react": "^15.4.2",
-    "react-native": "^0.41.2"
+    "react-native": "^0.41.2",
+    "react-native-button": "^1.8.2"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   ],
   "dependencies": {
     "lodash.isequal": "^4.5.0",
-    "react": "^15.4.2",
     "react-addons-pure-render-mixin": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-native-experimental-navigation": "0.26.x",
@@ -67,6 +66,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "jest": "19.0.1",
     "react-test-renderer": "15.4.2",
+    "react": "^15.4.2",
     "react-native": "^0.41.2"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
     "jest": "19.0.1",
-    "react-test-renderer": "15.4.2"
+    "react-test-renderer": "15.4.2",
+    "react-native": "^0.41.2"
   },
   "jest": {
     "preset": "react-native"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,6 +3303,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -3466,13 +3470,13 @@ mime-db@~1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.23.0.tgz#a31b4070adaea27d732ea333740a64d0ec9a6659"
 
-mime-types@2.1.11:
+mime-types@2.1.11, mime-types@~2.1.7, mime-types@~2.1.9:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.11.tgz#c259c471bda808a85d6cd193b430a5fae4473b3c"
   dependencies:
     mime-db "~1.23.0"
 
-mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.6, mime-types@~2.1.7, mime-types@~2.1.9:
+mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.6:
   version "2.1.14"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee"
   dependencies:
@@ -4938,11 +4942,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz#fe294d1d89e36c5be8b3195057f2e4bc74fc980e"
-
-whatwg-fetch@^1.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 


### PR DESCRIPTION
This will fix https://github.com/aksonov/react-native-router-flux/issues/1809

For testing you can use the following line dependencies of package.json:

```
	"dependencies": {
		"react": "16.0.0-alpha.6",
		"react-native": "0.43.4",
		"react-native-router-flux": "git:github.com/itinance/react-native-router-flux#fc1b8261144fe5f3132ac4940dd794ac06e9f351"
	},

```