### PR TITLE
Fix RN 0.44 compatibility

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -10,7 +10,7 @@ import React, {
   Component,
   PropTypes,
 } from 'react';
-import { BackAndroid } from 'react-native';
+import { BackHandler } from 'react-native';
 import NavigationExperimental from 'react-native-experimental-navigation';
 
 import Actions, { ActionMap } from './Actions';
@@ -52,7 +52,7 @@ class Router extends Component {
   }
 
   componentDidMount() {
-    BackAndroid.addEventListener('hardwareBackPress', this.handleBackAndroid);
+    BackHandler.addEventListener('hardwareBackPress', this.handleBackAndroid);
   }
 
   componentWillReceiveProps(props) {
@@ -61,7 +61,7 @@ class Router extends Component {
   }
 
   componentWillUnmount() {
-    BackAndroid.removeEventListener('hardwareBackPress', this.handleBackAndroid);
+    BackHandler.removeEventListener('hardwareBackPress', this.handleBackAndroid);
   }
 
   handleBackAndroid() {


### PR DESCRIPTION
BackAndroid is deprecated.  Please use BackHandler instead.

https://github.com/facebook/react-native/commit/b7e9374c649a8e08108ec3165d68d009b88f0dec