### PR TITLE
Updated View.propTypes to ViewPropTypes

### DIFF
--- a/Example/components/TabView.js
+++ b/Example/components/TabView.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {PropTypes} from "react";
-import {StyleSheet, Text, View} from "react-native";
+import {StyleSheet, Text, View, ViewPropTypes} from "react-native";
 import Button from 'react-native-button';
 import { Actions } from 'react-native-router-flux';
 
@@ -10,7 +10,7 @@ const contextTypes = {
 
 const propTypes = {
   name: PropTypes.string,
-  sceneStyle: View.propTypes.style,
+  sceneStyle: ViewPropTypes.style,
   title: PropTypes.string,
 };
 

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -35,6 +35,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  ViewPropTypes
 } from 'react-native';
 import Actions from './Actions';
 import _drawerImage from './menu_burger.png';
@@ -175,7 +176,7 @@ const propTypes = {
   wrapBy: PropTypes.any,
   component: PropTypes.any,
   backButtonTextStyle: Text.propTypes.style,
-  leftButtonStyle: View.propTypes.style,
+  leftButtonStyle: ViewPropTypes.style,
   leftButtonIconStyle: Image.propTypes.style,
   getTitle: PropTypes.func,
   titleWrapperStyle: Text.propTypes.style,
@@ -183,13 +184,13 @@ const propTypes = {
   titleOpacity: PropTypes.number,
   titleProps: PropTypes.any,
   position: PropTypes.object,
-  navigationBarStyle: View.propTypes.style,
+  navigationBarStyle: ViewPropTypes.style,
   navigationBarBackgroundImage: Image.propTypes.source,
   navigationBarBackgroundImageStyle: Image.propTypes.style,
   navigationBarTitleImage: Image.propTypes.source,
   navigationBarTitleImageStyle: Image.propTypes.style,
   navigationBarShowImageSelection: PropTypes.bool,
-  navigationBarSelecionStyle: View.propTypes.style,
+  navigationBarSelecionStyle: ViewPropTypes.style,
   renderTitle: PropTypes.any,
 };
 

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -35,7 +35,7 @@ import {
   Text,
   TouchableOpacity,
   View,
-  ViewPropTypes
+  ViewPropTypes,
 } from 'react-native';
 import Actions from './Actions';
 import _drawerImage from './menu_burger.png';

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -7,19 +7,19 @@
  *
  */
 import React, { PropTypes } from 'react';
-import { View, Text } from 'react-native';
+import { ViewPropTypes, Text } from 'react-native';
 
 export default class extends React.Component {
 
   // @todo - should all props be documented/specified here?
 
   static propTypes = {
-    tabBarStyle: View.propTypes.style,
-    tabBarSelectedItemStyle: View.propTypes.style,
-    tabBarIconContainerStyle: View.propTypes.style,
-    tabBarShadowStyle: View.propTypes.style,
-    tabSceneStyle: View.propTypes.style,
-    tabStyle: View.propTypes.style,
+    tabBarStyle: ViewPropTypes.style,
+    tabBarSelectedItemStyle: ViewPropTypes.style,
+    tabBarIconContainerStyle: ViewPropTypes.style,
+    tabBarShadowStyle: ViewPropTypes.style,
+    tabSceneStyle: ViewPropTypes.style,
+    tabStyle: ViewPropTypes.style,
     tabTitleStyle: Text.propTypes.style,
     tabSelectedTitleStyle: Text.propTypes.style,
     tabTitle: PropTypes.string,

--- a/src/TabbedView.js
+++ b/src/TabbedView.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ViewPropTypes } from 'react-native';
 import StaticContainer from 'react-static-container';
 
 const styles = StyleSheet.create({
@@ -17,7 +17,7 @@ class TabbedView extends Component {
   static propTypes = {
     navigationState: PropTypes.object.isRequired,
     renderScene: PropTypes.func.isRequired,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
   };
 
   constructor(props, context) {


### PR DESCRIPTION
To fix this error:

`
Warning: View.propTypes has been deprecated and will be removed in a future version of ReactNative. Use ViewPropTypes instead.`