### PR TITLE
Fix: Do Not Clobber Tab Children Stack

### DIFF
--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -226,12 +226,20 @@ function inject(state, action, props, scenes) {
         resetHistoryStack(state.children[ind]);
       }
 
-      state.children[ind] = getInitialState(
-        props,
-        scenes,
-        state.index,
-        { ...action, parentIndex: state.children[ind].parentIndex },
-      );
+      const activeChild = state.children[state.index];
+      const incomingChild = state.children[ind];
+
+      const incomingChildHadTabs = incomingChild.tabs;
+      const incomingChildWasActive = incomingChild.children.length > 1;
+      const activeChildIsIncomingChild = activeChild.sceneKey === action.key;
+      if (incomingChildHadTabs || !incomingChildWasActive || activeChildIsIncomingChild) {
+        state.children[ind] = getInitialState(
+          { ...props },
+          scenes,
+          state.index,
+          { ...action, parentIndex: state.children[ind].parentIndex },
+        );
+      }
 
       return { ...state, index: ind };
     }


### PR DESCRIPTION
## Overview 

This PR tweaks how jumps are handled so that:

* Jumping to a tab which has been navigated to a subscene will not cause that tab's `children` stack to be reset.
* Jumping to a tab that is already active will navigate the user back to the initial scene of that tab.

### Versions

* `react-native@0.44.2`
* `react-native-router-flux@3.39.2`

### Steps to Reproduce

Based on the example project at the time of writing, you can reproduce this behavior by doing the following:

1. Launch the application.
2. Press `Go to TabBar page`
3. Press `push new scene`
4. Press `Tab #4`
5. Press `Tab #2`

**Expected**: I am viewing the scene rendered after step 3.
**Actual**: I am viewing the scene rendered after step 2.

### Related Issues

* Issue #1913
* Issue #1725
* Issue #1703

### Before/After GIFs

| Broken Behavior | Fixed Behavior |
| --- | --- |
| ![unexpected-tab-behavior](https://cloud.githubusercontent.com/assets/1624195/26738113/205fd0e0-478a-11e7-97f1-a9d9ec66704a.gif) | ![expected-tab-behavior](https://cloud.githubusercontent.com/assets/1624195/26738119/247abe56-478a-11e7-8d3d-de670a55ecff.gif) |

### Misc

I haven't tested this with nested tabs, and I suspect that would cause issues too.  I'm happy to help investigate that.  Just let me know.  