### PR TITLE
Fix for #2019 - rightButton positioning on Android.

### DIFF
--- a/dist/NavBar.js
+++ b/dist/NavBar.js
@@ -261,14 +261,14 @@ paddingLeft:8,
 flexDirection:'row',
 transform:[{scaleX:_reactNative.I18nManager.isRTL?-1:1}]}),
 
-rightButton:_extends({
-position:'absolute'},
+rightButton:_extends({},
 _reactNative.Platform.select({
 ios:{
+position:'absolute',
 top:12},
 
 android:{
-top:10},
+top:0},
 
 windows:{
 top:8}}),{

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -262,13 +262,13 @@ const styles = StyleSheet.create({
     transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
   },
   rightButton: {
-    position: 'absolute',
     ...Platform.select({
       ios: {
+        position: 'absolute',
         top: 12,
       },
       android: {
-        top: 10,
+        top: 0,
       },
       windows: {
         top: 8,


### PR DESCRIPTION
Exactly like with the leftButton/backButton, `position: 'absolute'` was sending the button out of the visible area on Android.