### PR TITLE
Pass transitionConfig to Navigator

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -189,7 +189,7 @@ class App extends React.Component {
   }
 }
 
-function processScene(scene: Scene, inheritProps = {}, clones = [], wrapBy) {
+function processScene(scene: Scene, inheritProps = {}, clones = [], transitionConfig = false, wrapBy) {
   assert(scene.props, 'props should be defined');
   if (!scene.props.children) {
     return null;
@@ -286,22 +286,22 @@ function processScene(scene: Scene, inheritProps = {}, clones = [], wrapBy) {
   }
   const mode = modal ? 'modal' : 'card';
   if (lightbox) {
-    return LightboxNavigator(res, { mode, initialRouteParams, initialRouteName, navigationOptions: createNavigationOptions(commonProps) });
+    return LightboxNavigator(res, { transitionConfig, mode, initialRouteParams, initialRouteName, navigationOptions: createNavigationOptions(commonProps)});
   } else if (tabs) {
-    return TabNavigator(res, { lazy, initialRouteName, initialRouteParams, order, ...commonProps,
-      tabBarOptions: createTabBarOptions(commonProps), navigationOptions: createNavigationOptions(commonProps) });
+    return TabNavigator(res, { transitionConfig, lazy, initialRouteName, initialRouteParams, order, ...commonProps,
+      tabBarOptions: createTabBarOptions(commonProps), navigationOptions: createNavigationOptions(commonProps)});
   } else if (drawer) {
-    return DrawerNavigator(res, { initialRouteName, contentComponent, order, ...commonProps });
+    return DrawerNavigator(res, { transitionConfig, initialRouteName, contentComponent, order, ...commonProps });
   }
   if (navigator) {
-    return navigator(res, { lazy, initialRouteName, initialRouteParams, order, ...commonProps, navigationOptions: createNavigationOptions(commonProps) });
+    return navigator(res, { transitionConfig, lazy, initialRouteName, initialRouteParams, order, ...commonProps, navigationOptions: createNavigationOptions(commonProps)});
   }
-  return StackNavigator(res, { mode, initialRouteParams, initialRouteName, ...commonProps, navigationOptions: createNavigationOptions(commonProps) });
+  return StackNavigator(res, { transitionConfig, mode, initialRouteParams, initialRouteName, ...commonProps, navigationOptions: createNavigationOptions(commonProps)});
 }
 
 const Router = ({ createReducer, wrapBy = props => props, ...props }) => {
   const scene: Scene = props.children;
-  const AppNavigator = processScene(scene, props, [], wrapBy);
+  const AppNavigator = processScene(scene, props, [], props.transitionConfig, wrapBy);
   navigationStore.router = AppNavigator.router;
   navigationStore.reducer = createReducer && createReducer(props);
   RightNavBarButton = wrapBy(RightButton);
@@ -315,3 +315,4 @@ Router.propTypes = {
 };
 
 export default Router;
+


### PR DESCRIPTION
With this PR, you can create a custom transition and pass it via `transitionConfig` to the Router. You can choose the transition type when routing with 
```
Actions.test({transition:'myCustomTransition'})
```

Example:

```
let MyTransition = (index, position) => {
    const inputRange = [index - 1, index, index + 1];
    const opacity = position.interpolate({
        inputRange,
        outputRange: [0, 1, 1],
    });

    const scaleX = position.interpolate({
        inputRange,
        outputRange: ([0.4, 1, 1]),
    });

    return {
        opacity,
        transform: [
            {scaleX}
        ]
    };
};

let MyCustomTransition = (index, position) => {
    const inputRange = [index - 1, index, index + 1];
    const opacity = position.interpolate({
        inputRange,
        outputRange: [0, 1, 1],
    });

    const scaleY = position.interpolate({
        inputRange,
        outputRange: ([0.1, 1, 1]),
    });

    return {
        opacity,
        transform: [
            {scaleY}
        ]
    };
};

let TransitionConfiguration = () => {
    return {
        screenInterpolator: (sceneProps) => {

            const {position, scene} = sceneProps;
            const {index, route} = scene
            const params = route.params || {};
            const transition = params.transition || 'default';

            return {
                myCustomTransition: MyCustomTransition(index, position),
                default: MyTransition(index, position),
            }[transition];
        }
    }
};
```