### PR TITLE
Fixes #2155 

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "autobind-decorator": "^1.4.1",
-    "mobx": "^3.2.1",
-    "mobx-react": "^4.2.1",
+    "mobx": "^3.2.2",
+    "mobx-react": "^4.2.2",
     "react": "16.0.0-alpha.6",
     "react-native": "0.44.0",
     "react-native-button": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "mobx": "^3.1.16",
-    "mobx-react": "^4.2.1",
     "opencollective": "^1.0.3",
     "prop-types": "^15.5.10",
     "react-native-button": "^2.0.0",
@@ -44,6 +42,8 @@
     "react-test-renderer": "16.0.0-alpha.12"
   },
   "peerDependencies": {
+    "mobx": "^3.2.2",
+    "mobx-react": "^4.2.2",
     "react": "*",
     "react-native": "*"
   },

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "react-test-renderer": "16.0.0-alpha.12"
   },
   "peerDependencies": {
-    "mobx": "^3.2.2",
-    "mobx-react": "^4.2.2",
+    "mobx": "*",
+    "mobx-react": "*",
     "react": "*",
     "react-native": "*"
   },


### PR DESCRIPTION
This PR changes the requirement for mobx to be a peer dependency, as recommended on https://github.com/mobxjs/mobx/issues/1082.

###IMPORTANT###
Because of that, now the user will be required to manually install mobx and mobx-react. This is because peer dependencies are not automatically installed (as can be seen on https://docs.npmjs.com/files/package.json#peerdependencies).

