### PR TITLE
Install by https is more common

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Actions.refresh({param1: 'hello', param2: 'world'})
 
 ```bash
 # Get the code
-git clone git@github.com:aksonov/react-native-router-flux.git
+git clone https://github.com/aksonov/react-native-router-flux.git
 cd react-native-router-flux/Example
 
 # Install dependencies


### PR DESCRIPTION
Installing by https do not require any additional setups. For git I got error: 
```bash
λ  git clone git@github.com:aksonov/react-native-router-flux.git
Cloning into 'react-native-router-flux'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```