### PR TITLE
Allow special characters in route keys and avoid unintuitive js parsing errors

### DIFF
--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -335,7 +335,7 @@ class NavigationStore {
       props.init = true;
       if (!this[key]) {
         this[key] = new Function('actions', 'props', 'type', // eslint-disable-line no-new-func
-          `return function ${key}(params){ actions.execute(type, '${key}', props, params)}`)(this, { ...commonProps, ...props }, type);
+          `return function ${key.replace(/\W/g, '_')}(params){ actions.execute(type, '${key}', props, params)}`)(this, { ...commonProps, ...props }, type);
       }
 
       if ((onEnter || on || (component && component.onEnter)) && !this[key + OnEnter]) {


### PR DESCRIPTION
We need to use slash symbol in scene keys because of partially sharing navigation logic between web and mobile apps. rnrf v3 used to support this without any problems. Without this feature migrating to v4 is too painful.

The generated function name shouldn't affect any logic, it may only be useful in stack traces I think.