### PR TITLE
Allow 1-deep nested arrays of Scenes to support structured configuration for larger projects

### DIFF
--- a/dist/navigationStore.js
+++ b/dist/navigationStore.js
@@ -290,7 +290,8 @@ if(drawer){
 commonProps.drawerImage=commonProps.drawerImage||_menu_burger2.default;
 }
 
-var children=!Array.isArray(parentProps.children)?[parentProps.children]:[].concat(_toConsumableArray(parentProps.children));
+
+var children=!Array.isArray(parentProps.children)?[parentProps.children]:[].concat.apply([],parentProps.children);
 
 if(!drawer&&!tabs){
 children.push.apply(children,_toConsumableArray(clones));

--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -290,7 +290,8 @@ class NavigationStore {
       commonProps.drawerImage = commonProps.drawerImage || _drawerImage;
     }
 
-    const children = !Array.isArray(parentProps.children) ? [parentProps.children] : [...parentProps.children];
+    // allow 1-deep nested arrays of Scenes to support structured configuration for larger projects
+    const children = !Array.isArray(parentProps.children) ? [parentProps.children] : [].concat.apply([], parentProps.children);
     // add clone scenes
     if (!drawer && !tabs) {
       children.push(...clones);


### PR DESCRIPTION
For larger projects it is convenient to divide scenes configuration by modules. If the new module needs it's own navigator this is ok, but often you just want to configure some more screens for the existing top-level stack navigator. In v3 that was achievable via explicitly adding array of childrens of sub-module config:
```jsx
// app/scenes.jsx
<Scene key="root">
  {submodule1Scenes.props.children}
  {submodule2Scenes.props.children}
</Scene>

// submodule1/scenes.jsx
submodule1Scenes = (
  <Scene>
     <Scene key="/test" component={Test}/>
     <Scene key="/test1" component={Test1}/>
  </Scene>
)
```

This was ugly but workable solution. v4 throws exception for such trick and doesn't provide any alternative solution. This small change allows such trick and makes v4 more compatible with v3 configuration.

Better solution would be to introduce a new configuration node (may be call it ``<Group></Group>``) to contain sub-module configuration without introducing new sub-navigator.

P.S.: Unfortunately I'm unable to commit dist files because ``npm run build`` doesn't work for me (#2240). But I've tested this by altering dist code manually.