### PR TITLE
Fix for reset actions being unable to find nested scenes

### DIFF
--- a/dist/navigationStore.js
+++ b/dist/navigationStore.js
@@ -600,7 +600,7 @@ _this3.dispatch({type:ActionConst.REPLACE,routeName:routeName,params:params});
 
 reset=function(routeName,data){
 var params=filterParam(data);
-_this3.dispatch(_reactNavigation.NavigationActions.reset({key:null,index:0,actions:[_reactNavigation.NavigationActions.navigate({
+_this3.dispatch(_reactNavigation.NavigationActions.reset({index:0,actions:[_reactNavigation.NavigationActions.navigate({
 routeName:routeName,
 params:params})]}));
 

--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -600,7 +600,7 @@ class NavigationStore {
 
   reset = (routeName, data) => {
     const params = filterParam(data);
-    this.dispatch(NavigationActions.reset({ key: null, index: 0, actions: [NavigationActions.navigate({
+    this.dispatch(NavigationActions.reset({ index: 0, actions: [NavigationActions.navigate({
       routeName,
       params,
     })] }));


### PR DESCRIPTION
Found that when wrapping scenes in a Modal, Lightbox or Overlay that _only_ the top level keys for those wrappers were available to perform a `reset` action to. The `replace` action wasn't sufficient as it still allowed swiping from the left to navigate back to the previous scene.

This PR fixes this issue and allows a `reset` to any key just like `push`, etc do.

However, I'm uncertain if this potentially breaks any other functionality - and it should definitely be reviewed thoroughly. Potentially fixes closed issue #2261 that was worked around.