### PR TITLE
Ensure example works by referencing specific version of react-navigation

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -17,7 +17,7 @@
     "react-native-button": "^2.0.0",
     "react-native-message-bar": "^1.6.0",
     "react-native-router-flux": "file:../",
-    "react-navigation": "^1.0.0-beta.11"
+    "react-navigation": "1.0.0-beta.11"
   },
   "devDependencies": {
     "babel-jest": "20.0.3",


### PR DESCRIPTION
Discovered that the example would error due to conflicts with React Navigation. Chose to specify the exact version in the example package.json (as originally supplied by the example author), and the sample ran without any issues. Hope this helps others until ready to upgrade example with all latest changes to move to most recent versions.