### PR TITLE
Fix passing down wrong overlay navigation state in OverlayNavigator

### DIFF
--- a/dist/OverlayNavigator.js
+++ b/dist/OverlayNavigator.js
@@ -22,11 +22,13 @@ routes=state.routes;
 
 var Component=routeConfigs[tabsConfig.initialRouteName].screen;
 var initialIndex=0;
+var routesMap={};
 for(var i=0;i<routes.length;i++){
 var route=routes[i];
 if(route.routeName===tabsConfig.initialRouteName){
 initialIndex=i;
 }
+routesMap[route.routeName]=route;
 }
 var initialRouteName=tabsConfig.initialRouteName||routes[initialIndex].routeName;
 var overlays=[];
@@ -34,12 +36,12 @@ for(var _i=0;_i<tabsConfig.order.length;_i++){
 var routeName=tabsConfig.order[_i];
 if(initialRouteName!==routeName){
 var Overlay=routeConfigs[routeName].screen;
-overlays.push(_react2.default.createElement(Overlay,{key:routeName,navigation:{dispatch:dispatch,state:state},__source:{fileName:_jsxFileName,lineNumber:37}}));
+overlays.push(_react2.default.createElement(Overlay,{key:routeName,navigation:{dispatch:dispatch,state:routesMap[routeName]},__source:{fileName:_jsxFileName,lineNumber:39}}));
 }
 }
 var ContentComponent=tabsConfig.contentComponent||_reactNative.View;
-return _react2.default.createElement(ContentComponent,{style:{flex:1},__source:{fileName:_jsxFileName,lineNumber:41}},
-_react2.default.createElement(Component,{navigation:{dispatch:dispatch,state:routes[initialIndex]},__source:{fileName:_jsxFileName,lineNumber:42}}),
+return _react2.default.createElement(ContentComponent,{style:{flex:1},__source:{fileName:_jsxFileName,lineNumber:43}},
+_react2.default.createElement(Component,{navigation:{dispatch:dispatch,state:routes[initialIndex]},__source:{fileName:_jsxFileName,lineNumber:44}}),
 overlays);
 
 });

--- a/src/OverlayNavigator.js
+++ b/src/OverlayNavigator.js
@@ -22,11 +22,13 @@ const OverlayNavigator = (
     // Figure out what to render based on the navigation state and the router:
     const Component = routeConfigs[tabsConfig.initialRouteName].screen;
     let initialIndex = 0;
+    const routesMap = {};
     for (let i = 0; i < routes.length; i++) {
       const route = routes[i];
       if (route.routeName === tabsConfig.initialRouteName) {
         initialIndex = i;
       }
+      routesMap[route.routeName] = route;
     }
     const initialRouteName = tabsConfig.initialRouteName || routes[initialIndex].routeName;
     const overlays = [];
@@ -34,7 +36,7 @@ const OverlayNavigator = (
       const routeName = tabsConfig.order[i];
       if (initialRouteName !== routeName) {
         const Overlay = routeConfigs[routeName].screen;
-        overlays.push(<Overlay key={routeName} navigation={{ dispatch, state }} />);
+        overlays.push(<Overlay key={routeName} navigation={{ dispatch, state: routesMap[routeName] }} />);
       }
     }
     const ContentComponent = tabsConfig.contentComponent || View;


### PR DESCRIPTION
We shouldn't pass the down the `state` directly to the overlay children,
instead, pass the corresponding state in `state.routes`.

This bug also caused the issue mentioned  in  #2407.