### PR TITLE
Hide navbar programmatically

### DIFF
--- a/Example/Example.js
+++ b/Example/Example.js
@@ -130,7 +130,7 @@ const Example = () => (
                 Wrapper Scene needed to fix a bug where the tabs would
                 reload as a modal ontop of itself
               */}
-              <Scene hideNavBar>
+              <Scene>
                 <Tabs
                   key="tabbar"
                   swipeEnabled
@@ -155,7 +155,6 @@ const Example = () => (
                       title="Tab #1_1"
                       onRight={() => alert('Right button')}
                       rightTitle="Right"
-
                     />
 
                     <Scene

--- a/Example/components/TabView.js
+++ b/Example/components/TabView.js
@@ -26,6 +26,14 @@ const styles = StyleSheet.create({
 });
 
 class TabView extends React.Component {
+  state = { hideNavBar: false }
+
+  toggleNavBar = () => {
+    this.setState({ hideNavBar: !this.state.hideNavBar }, () =>
+      Actions.refresh({ hideNavBar: this.state.hideNavBar })
+    );
+  }
+
   render() {
     return (
       <View style={[styles.container, this.props.sceneStyle]}>
@@ -44,6 +52,7 @@ class TabView extends React.Component {
         <Button onPress={() => { Actions.tab_4(); }}>Switch to tab4</Button>
         <Button onPress={() => { Actions.tab_5({ data: 'test!' }); }}>Switch to tab5 with data</Button>
         <Button onPress={() => { Actions.echo(); }}>push clone scene (EchoView)</Button>
+        <Button onPress={() => { this.toggleNavBar(); }}>Toggle NavBar</Button>
       </View>
     );
   }

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -3256,8 +3256,8 @@ react-native-message-bar@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/react-native-message-bar/-/react-native-message-bar-1.6.0.tgz#79623e89655475216927090771b0238616b6f1c7"
 
-"react-native-router-flux@file:../":
-  version "4.0.0-beta.21"
+"react-native-router-flux@file:..":
+  version "4.0.0-beta.22"
   dependencies:
     lodash.isequal "^4.5.0"
     mobx "^3.1.16"

--- a/dist/navigationStore.js
+++ b/dist/navigationStore.js
@@ -213,7 +213,11 @@ res.tabBarVisible=false;
 res.tabBarVisible=false;
 }
 
-if(hideNavBar){
+if(navigationParams.hideNavBar!=null){
+if(navigationParams.hideNavBar){
+res.header=false;
+}
+}else if(hideNavBar){
 res.header=null;
 }
 
@@ -274,7 +278,7 @@ store.deleteRef(originalRouteName(navigation.state.routeName));
 }},{key:'render',value:function render()
 {var _this2=this;
 var navigation=this.props.navigation;
-return _react2.default.createElement(Component,_extends({ref:function ref(_ref5){return _this2.ref=_ref5;}},this.props,extendProps(navigation.state.params,store),{name:navigation.state.routeName,__source:{fileName:_jsxFileName,lineNumber:277}}));
+return _react2.default.createElement(Component,_extends({ref:function ref(_ref5){return _this2.ref=_ref5;}},this.props,extendProps(navigation.state.params,store),{name:navigation.state.routeName,__source:{fileName:_jsxFileName,lineNumber:281}}));
 }}]);return Wrapped;}(_react2.default.Component),_class.propTypes={navigation:_propTypes2.default.object},_temp);
 
 return wrapper(Wrapped);
@@ -282,7 +286,7 @@ return wrapper(Wrapped);
 
 
 function StatelessWrapped(_ref6){var navigation=_ref6.navigation,props=_objectWithoutProperties(_ref6,['navigation']);
-return _react2.default.createElement(Component,_extends({},props,{navigation:navigation},extendProps(navigation.state.params,store),{name:navigation.state.routeName,__source:{fileName:_jsxFileName,lineNumber:285}}));
+return _react2.default.createElement(Component,_extends({},props,{navigation:navigation},extendProps(navigation.state.params,store),{name:navigation.state.routeName,__source:{fileName:_jsxFileName,lineNumber:289}}));
 }
 StatelessWrapped.propTypes={
 navigation:_propTypes2.default.object};
@@ -476,8 +480,8 @@ if(lightbox){
 return(0,_LightboxNavigator2.default)(res,_extends({mode:mode,initialRouteParams:initialRouteParams,initialRouteName:initialRouteName},commonProps,{navigationOptions:createNavigationOptions(commonProps)}));
 }else if(tabs){
 if(!tabBarComponent){
-tabBarComponent=tabBarPosition==='top'?function(props){return _react2.default.createElement(_reactNavigation.TabBarTop,_extends({},props,commonProps,{__source:{fileName:_jsxFileName,lineNumber:479}}));}:
-function(props){return _react2.default.createElement(_reactNavigation.TabBarBottom,_extends({},props,commonProps,{__source:{fileName:_jsxFileName,lineNumber:480}}));};
+tabBarComponent=tabBarPosition==='top'?function(props){return _react2.default.createElement(_reactNavigation.TabBarTop,_extends({},props,commonProps,{__source:{fileName:_jsxFileName,lineNumber:483}}));}:
+function(props){return _react2.default.createElement(_reactNavigation.TabBarBottom,_extends({},props,commonProps,{__source:{fileName:_jsxFileName,lineNumber:484}}));};
 }
 if(!tabBarPosition){
 tabBarPosition=_reactNative.Platform.OS==='android'?'top':'bottom';

--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -213,7 +213,11 @@ function createNavigationOptions(params) {
       res.tabBarVisible = false;
     }
 
-    if (hideNavBar) {
+    if (navigationParams.hideNavBar != null) {
+      if (navigationParams.hideNavBar) {
+        res.header = false;
+      }
+    } else if (hideNavBar) {
       res.header = null;
     }
 


### PR DESCRIPTION
According to this issue #2441 and this commit (https://github.com/aksonov/react-native-router-flux/commit/29090461469d4eb907072c63e9881f99205fab73) I am adding this functionallity again. I was trying to catch the issue when NavBar was hiding inside Drawer but I didn't succeed. May be I don't know something but according to the React Navigation docs it's not possible to put NavBar inside Drawer. @aksonov could you provide more detailed example for me to catch this error? As I said in commit comment - there are a lot of people that need this functionality so we need to resolve this problem.