### PR TITLE
[Fix] Router - sceneStyle must be View.propTypes.style

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { observer } from 'mobx-react/native';
-import { BackHandler } from 'react-native';
+import { ViewPropTypes, BackHandler } from 'react-native';
 import navigationStore from './navigationStore';
 import PropTypes from 'prop-types';
 import { addNavigationHelpers } from 'react-navigation';
@@ -59,7 +59,7 @@ Router.propTypes = {
   navigator: PropTypes.func,
   wrapBy: PropTypes.func,
   getSceneStyle: PropTypes.func,
-  sceneStyle: PropTypes.object,
+  sceneStyle: ViewPropTypes.style,
   children: PropTypes.element,
 };
 


### PR DESCRIPTION
Hey!

I am interested to use result of `StyleSheet.create` for `Router` `sceneStyle` property but it's object for now, but should be another

Unexpected warning:

![image](https://user-images.githubusercontent.com/572096/31777574-04b999d6-b4f7-11e7-8269-cbf6e1e2bba9.png)


Thank