### PR TITLE
Fix drawerPosition row for Drawer table

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -108,7 +108,7 @@ Can use all `prop` as listed in `Scene` as `<Drawer>`, syntatic sugar for `<Scen
 | `drawerImage` | `Image` |  | Image to substitute drawer 'hamburger' icon, you have to set it together with `drawer` prop |
 | `drawerIcon` | `React.Component` |  | Arbitrary component to be used for drawer 'hamburger' icon, you have to set it together with `drawer` prop |
 | `hideDrawerButton` | `boolean` | `false` | Boolean to show or not the drawerImage or drawerIcon |
-| `drawerPosition` | `string`  | Determines whether the drawer is on the right or the left. Keywords accepted are `right` and `left` |
+| `drawerPosition` | `string`  | `left` | Determines whether the drawer is on the right or the left. Keywords accepted are `right` and `left` |
 | `drawerWidth` | `number`  |  | The width, in pixels, of the drawer (optional)
 
 


### PR DESCRIPTION
Apparently this row had missing its default value and the description was being displayed in the Default value column