### PR TITLE
Quick fixes for typing errors on: error TS2411

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -148,8 +148,8 @@ interface ActionsStatic {
     refresh: (props?: any) => void;
     replace: (sceneKey: string, props?: any) => void;
     reset: (sceneKey: string, props?: any) => void;
-    drawerOpen?: () => void;
-    drawerClose?: () => void;
+    drawerOpen?: any;
+    drawerClose?: any;
 
 }
 interface ActionsGenericStatic extends ActionsStatic {


### PR DESCRIPTION
Quick fix for the following errors:
```
node_modules/react-native-router-flux/index.d.ts(156,5): error TS2411: Property 'drawerClose'
of type '((props?: any) => void) | undefined' is not assignable to string index type '(props?:
 any) => void'.
node_modules/react-native-router-flux/index.d.ts(156,5): error TS2411: Property 'drawerOpen' o
f type '((props?: any) => void) | undefined' is not assignable to string index type '(props?:
any) => void'
```