### PR TITLE
Adds panHandlers to wrapping scene in tabs example

### DIFF
--- a/Example/Example.js
+++ b/Example/Example.js
@@ -135,7 +135,7 @@ const Example = () => (
                 Wrapper Scene needed to fix a bug where the tabs would
                 reload as a modal ontop of itself
               */}
-              <Scene hideNavBar>
+              <Scene hideNavBar panHandlers={null}>
                 <Tabs
                   key="tabbar"
                   swipeEnabled


### PR DESCRIPTION
This is a very tiny change.

In the tabs example, the bug-wrapping `<Scene>` does not contain `panHandlers={null}`

When using this as an example to build your own Tab system, some might notice that swiping from the far left of a modern iOS device causes you to accidentally swipe back to the originating scene or the `initial` one in the root stack. 

Adding `panHandlers={null}` to this wrapping <Scene> prevents this from happening, giving the Tabs their own independent "space" so to say.

IF a PR against the Example is not the best place for this let me know, I don't know how else to document this critical oddity. 