### PR TITLE
Fix wrong logic when back pressed

### DIFF
--- a/dist/Router.js
+++ b/dist/Router.js
@@ -29,7 +29,7 @@ App=(0,_native.observer)(_class=(_temp2=_class2=function(_React$Component){_inhe
 
 
 
-onBackPress=function(){return!_navigationStore2.default.pop();},_this.
+onBackPress=function(){return _navigationStore2.default.pop();},_this.
 
 handleDeepURL=function(e){return _this.parseDeepURL(e.url);},_this.
 

--- a/src/Router.js
+++ b/src/Router.js
@@ -29,7 +29,7 @@ class App extends React.Component {
     Linking.removeEventListener('url', this.handleDeepURL);
   }
 
-  onBackPress = () => !navigationStore.pop();
+  onBackPress = () => navigationStore.pop();
 
   handleDeepURL = (e) => this.parseDeepURL(e.url);
 


### PR DESCRIPTION
When back button was pressed,
`navigationStore.pop()` will return `true` if the previous scene got poped,
so return the result directly in `onBackPress` function to prevent app from being exited.
