### PR TITLE
Drawer fixed, faulty closeDrawer removed, androidBack support added

### DIFF
--- a/Example/Example.js
+++ b/Example/Example.js
@@ -62,12 +62,21 @@ const getSceneStyle = () => ({
 // on Android, the URI prefix typically contains a host in addition to scheme
 const prefix = Platform.OS === 'android' ? 'mychat://mychat/' : 'mychat://';
 
+const onBackPress = () => {
+    if (Actions.state.index !== 0) {
+      return false
+    }
+    Actions.pop()
+    return true
+  }
+
 const Example = () => (
   <Router
     createReducer={reducerCreate}
     getSceneStyle={getSceneStyle}
     uriPrefix={prefix}
-  >
+    backAndroidHandler={onBackPress}>
+
     <Overlay key="overlay">
       <Modal key="modal"
         hideNavBar
@@ -130,6 +139,9 @@ const Example = () => (
               contentComponent={DrawerContent}
               drawerImage={MenuIcon}
               drawerWidth={300}
+            drawerOpenRoute = 'DrawerOpen'
+        	drawerCloseRoute = 'DrawerClose'
+        	drawerToggleRoute = 'DrawerToggle'
             >
               {/*
                 Wrapper Scene needed to fix a bug where the tabs would

--- a/Example/components/drawer/DrawerContent.js
+++ b/Example/components/drawer/DrawerContent.js
@@ -29,8 +29,8 @@ class DrawerContent extends React.Component {
   render() {
     return (
       <View style={styles.container}>
-        <Text>Drawer Content</Text>
-        <Button onPress={Actions.closeDrawer}>Back</Button>
+        {/* <Text>Drawer Content</Text>
+        <Button onPress={Actions.closeDrawer}>Back</Button> */}
         <Text>Title: {this.props.title}</Text>
         {this.props.name === 'tab1_1' &&
           <Button onPress={Actions.tab_1_2}>next screen for tab1_1</Button>


### PR DESCRIPTION
- Drawer had an error, fixed it.
- There was a closeDrawer command in DrawerContent.js which wasnt working so removed it
- Android back wasn't supported so added that.
- Before:
![screenshot_20171228-212206](https://user-images.githubusercontent.com/23319631/34416756-fa221196-ec1a-11e7-92fc-bdd23ea2f8b1.jpg)
- Before:
![screenshot_20171228-212712](https://user-images.githubusercontent.com/23319631/34416758-fad14756-ec1a-11e7-87ec-3468e1363595.jpg)
- After:
![screenshot_20171228-212514](https://user-images.githubusercontent.com/23319631/34416757-fa6203dc-ec1a-11e7-8492-9c484721761b.jpg)
- After:
![screenshot_20171228-212728](https://user-images.githubusercontent.com/23319631/34416759-fb0f0c1c-ec1a-11e7-80a2-409c623b2544.jpg)
