### PR TITLE
Component prop should be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ export var Scene: SceneStatic;
 export type Scene = SceneStatic;
 interface SceneProps extends React.Props<Scene> {
     key: string;
-    component: React.ComponentType<any>
+    component?: React.ComponentType<any>
     back?: boolean;
     init?: boolean;
     clone?: boolean;


### PR DESCRIPTION
The interface SceneProps should have the component prop set to optional (?), because it won't build in typescript when using a Nested Scene for Tabs. The docs claim to have this prop as and (semi)-optional.