### PR TITLE
Update API.md: add upperCaseLabel in Tabs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -99,6 +99,7 @@ Can use all `props` listed above in `<Scene>` as `<Tabs>` is syntatic sugar for 
 | `animationEnabled`     | `boolean` | `true` | Enable or disable tab swipe animation. |
 | `tabBarOnPress`     | `function` | | Custom tab bar icon press. |
 | `backToInitial`     | `boolean` | `false` | Back to initial screen on focused tab if tab icon was tapped. |
+| `upperCaseLabel`     | `boolean` | `true` | Whether to make label uppercase, default is true. |
 
 ## Stack (`<Stack>`)
 A component to group Scenes together for its own stack based navigation. Using this will create a separate navigator for this stack, so expect two navbars to appear unless you add `hideNavBar`.


### PR DESCRIPTION
From [react-navigation doc](https://reactnavigation.org/docs/tab-navigator.html#tabbaroptions-for-tabbartop-default-tab-bar-on-android), `upperCaseLabel` (bool) allow us to disable the default uppercase for tab labels

(Tested with `4.0.0-beta.28`)