### PR TITLE
fix error in navigationStore.js that appears when Scene's tabIcon is …

### DIFF
--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -230,7 +230,7 @@ function createNavigationOptions(params) {
     if (backToInitial) {
       res.tabBarOnPress = ({ scene, jumpToIndex }) => {
         if (scene.focused) {
-          if (scene.route.index !== 0) {
+          if (scene.route.index !== 0 && scene.route.routes) {
             // go to first screen of the StackNavigator with reset
             // navigation.dispatch(NavigationActions.reset({
             //   index: 0,


### PR DESCRIPTION
…pressed (in a Tabs with 'backToInitial')

**Reproduce error:**

Try to have a `Tabs` component with `backToInitial`, containing children which are `Scene` or `Stack` of scenes.

When click on child `Scene`'s tabIcon, it throws an error like: `.. length of undefined`, cause the `Scene` doesn't contain any scene.

**error**

[this line](https://github.com/aksonov/react-native-router-flux/pull/2927/files#diff-2c2bc1d792d94da8f451749a3b894588R240)

**Tested version**

 v4.0.0-beta.28