### PR TITLE
WIP: migration guide for DefaultRenderer

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -14,6 +14,7 @@ https://github.com/react-community/react-navigation/issues/1493
 * No `direction` attribute is supported for custom transitions. For vertical transition add `modal` to parent `Scene`.
 * tabBarSelectedItemStyle is not supported. Instead please use React Navigation TabBar params for tabs Scene: `activeTintColor`, `inactiveTintColor`, etc (https://reactnavigation.org/docs/navigators/tab)
 * To make multiple pops you could use `Actions.popTo(sceneName)` where sceneName is name of scene you want to see (it should be not container, i.e. scene with `component`)
+* No longer exports DefaultRenderer
 * Possible other stuff...
 
 Check Example project for this repository


### PR DESCRIPTION
4.x appears to no longer export DefaultRenderer, at least not under the same name. The migration guide should probably mention that. Ideally it would also explain with what it should be replaced