### PR TITLE
migrate mobx to peer and dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   },
   "dependencies": {
     "lodash.isequal": "^4.5.0",
-    "mobx": "^3.3.1",
-    "mobx-react": "^4.3.4",
     "opencollective": "^1.0.3",
     "path-to-regexp": "^2.1.0",
     "prop-types": "^15.6.0",
@@ -42,6 +40,8 @@
     "eslint-plugin-react": "^5.0.1",
     "estraverse-fb": "^1.3.2",
     "jest": "20.0.4",
+    "mobx": "^4.1.1",
+    "mobx-react": "^5.0.0",
     "prettier-eslint": "^6.4.2",
     "prettier-eslint-cli": "^4.1.1",
     "react": "16.0.0",
@@ -50,7 +50,9 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "mobx": "3.x || 4.x",
+    "mobx-react": "4.x || 5.x"
   },
   "jest": {
     "preset": "react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,13 +2560,9 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^2.2.0:
+hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
-
-hoist-non-react-statics@^2.3.1:
-  version "2.5.0"
-  resolved "http://localhost:4873/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3709,13 +3705,13 @@ minimist@~0.0.1:
 
 mobx-react@^5.0.0:
   version "5.0.0"
-  resolved "http://localhost:4873/mobx-react/-/mobx-react-5.0.0.tgz#8d5a33be376fa22b184a6f555d40a6a3a8459a16"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-5.0.0.tgz#8d5a33be376fa22b184a6f555d40a6a3a8459a16"
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
 mobx@^4.1.1:
   version "4.1.1"
-  resolved "http://localhost:4873/mobx/-/mobx-4.1.1.tgz#7ce7ef92b22e85271d1fc274a124d7fa32fcceeb"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-4.1.1.tgz#7ce7ef92b22e85271d1fc274a124d7fa32fcceeb"
 
 morgan@~1.6.1:
   version "1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,9 +2560,13 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.3.1:
+hoist-non-react-statics@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
+
+hoist-non-react-statics@^2.3.1:
+  version "2.5.0"
+  resolved "http://localhost:4873/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3703,15 +3707,15 @@ minimist@~0.0.1:
   dependencies:
     minimist "0.0.8"
 
-mobx-react@^4.3.4:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-4.3.5.tgz#76853f2f2ef4a6f960c374bcd9f01e875929c04c"
+mobx-react@^5.0.0:
+  version "5.0.0"
+  resolved "http://localhost:4873/mobx-react/-/mobx-react-5.0.0.tgz#8d5a33be376fa22b184a6f555d40a6a3a8459a16"
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-mobx@^3.3.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.4.1.tgz#37abe5ee882d401828d9f26c6c1a2f47614bbbef"
+mobx@^4.1.1:
+  version "4.1.1"
+  resolved "http://localhost:4873/mobx/-/mobx-4.1.1.tgz#7ce7ef92b22e85271d1fc274a124d7fa32fcceeb"
 
 morgan@~1.6.1:
   version "1.6.1"


### PR DESCRIPTION
To avoid mobx update dependency everytime and to not force projects to upgrade with RNRF...

A far more better option is to change these dependencies to peer dependencies ...
Mobx Issue and related docs:
mobxjs/mobx#1082

Mobx docs:

If there should be only one mobx instance (libraries should cooperate & react to each other)
Use peer dependencies