### PR TITLE
Add "none" to type HeaderModeType.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,7 @@ interface TabSceneProps extends React.Props<Scene> {
     tabBarLabel?: string;
 }
 interface SceneStatic extends React.ComponentClass<SceneProps & TabsProps & TabSceneProps & DrawerProps & ModalProps> { }
-export type HeaderModeType = "float" | "screen";
+export type HeaderModeType = "float" | "screen" | "none";
 
 // Tabs
 export var Tabs: TabsStatic;


### PR DESCRIPTION
The documentation specifies that `none` is an acceptable `HeaderModeType`.