### PR TITLE
Fixed a Double Negative

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -23,7 +23,7 @@
 | `uriPrefix`     | `string` |  | A uri prefix to strip from incoming urls for deep linking. For example, if you wanted to support deep linking from `www.example.com/user/1234/`, then you could pass `example.com` to only match paths against `/user/1234/`. |
 
 ## Scene:
-The basic routing component for this router, all `<Scene>` components require a `key` prop that must be unique. A parent `<Scene>` cannot not have a `component` as a `prop` as it will act as a grouping component for its children.
+The basic routing component for this router, all `<Scene>` components require a `key` prop that must be unique. A parent `<Scene>` must have a `component` as a `prop` as it will act as a grouping component for its children.
 
 | Property | Type | Default | Description |
 |-----------|----------|----------|--------------------------------------------|


### PR DESCRIPTION
Can be confusing for people with minor dyslexia as they can interpret it as "Parent Scene cannot have ....." instead of "Parent scene cannot not have ...".