### PR TITLE
Upgrade react-navigation@2.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "opencollective": "^1.0.3",
     "path-to-regexp": "^2.2.1",
     "prop-types": "^15.6.2",
-    "react-navigation": "^2.8.0"
+    "react-navigation": "^2.11.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.54",


### PR DESCRIPTION
Upgrade react-navigation@2.11.2 to prevent break jest test case