### PR TITLE
Fix circleci build failed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,6 @@ jobs:
     docker:
       - image: circleci/node:8
     steps:
-      - run:
-          name: temporary-eslint-airbnb-config-install
-          command: |
-            git clone https://github.com/airbnb/javascript.git --branch eslint-config-airbnb-v16.1.0 --single-branch ~/airbnb-style
-            cd ~/airbnb-style/ && yarn install
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: temporary-eslint-airbnb-config-install
           command: |
-            git clone https://github.com/airbnb/javascript.git ~/airbnb-style
+            git clone https://github.com/airbnb/javascript.git --branch eslint-config-airbnb-v16.1.0 --single-branch ~/airbnb-style
             cd ~/airbnb-style/ && yarn install
       - checkout
       - restore_cache:

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "*/@babel/code-frame": "7.0.0-beta.54"
   },
   "dependencies": {
+    "eslint-config-airbnb": "16.1.0",
     "lodash.isequal": "^4.5.0",
     "opencollective": "^1.0.3",
     "path-to-regexp": "^2.2.1",
@@ -40,8 +41,6 @@
     "babel-eslint": "9.0.0-beta.3",
     "babel-jest": "^23.4.0",
     "eslint": "^5.2.0",
-    "eslint-config-airbnb": "file:../airbnb-style/packages/eslint-config-airbnb",
-    "eslint-config-airbnb-base": "file:../airbnb-style/packages/eslint-config-airbnb-base",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-import": "^2.13.0",

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -91,10 +91,8 @@ export function LeftButton(state) {
     );
   }
   if (!!state.onLeft ^ !!(leftTitle || buttonImage || menuIcon)) {
-    console.warn(
-      `Both onLeft and leftTitle/leftButtonImage
-            must be specified for the scene: ${state.name}`,
-    );
+    console.warn(`Both onLeft and leftTitle/leftButtonImage
+            must be specified for the scene: ${state.name}`);
   }
   return null;
 }
@@ -156,10 +154,8 @@ export function RightButton(state) {
     );
   }
   if (!!state.onRight ^ !!(typeof rightTitle !== 'undefined' || typeof buttonImage !== 'undefined')) {
-    console.warn(
-      `Both onRight and rightTitle/rightButtonImage
-            must be specified for the scene: ${state.routeName}`,
-    );
+    console.warn(`Both onRight and rightTitle/rightButtonImage
+            must be specified for the scene: ${state.routeName}`);
   }
   return null;
 }

--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -910,18 +910,16 @@ class NavigationStore {
 
   reset = (routeName, data) => {
     const params = filterParam(data);
-    this.dispatch(
-      StackActions.reset({
-        key: null,
-        index: 0,
-        actions: [
-          NavigationActions.navigate({
-            routeName,
-            params,
-          }),
-        ],
-      }),
-    );
+    this.dispatch(StackActions.reset({
+      key: null,
+      index: 0,
+      actions: [
+        NavigationActions.navigate({
+          routeName,
+          params,
+        }),
+      ],
+    }));
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2574,7 +2574,7 @@ errorhandler@^1.5.0:
     accepts "~1.3.3"
     escape-html "~1.0.3"
 
-es-abstract@^1.10.0, es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0:
+es-abstract@^1.10.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
@@ -2611,27 +2611,17 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-airbnb-base@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.0.0.tgz#2ee6279c4891128e49d6445b24aa13c2d1a21450"
+eslint-config-airbnb-base@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
   dependencies:
     eslint-restricted-globals "^0.1.1"
-    object.assign "^4.1.0"
-    object.entries "^1.0.4"
 
-"eslint-config-airbnb-base@file:../airbnb-style/packages/eslint-config-airbnb-base":
-  version "13.0.0"
+eslint-config-airbnb@16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz#2546bfb02cc9fe92284bf1723ccf2e87bc45ca46"
   dependencies:
-    eslint-restricted-globals "^0.1.1"
-    object.assign "^4.1.0"
-    object.entries "^1.0.4"
-
-"eslint-config-airbnb@file:../airbnb-style/packages/eslint-config-airbnb":
-  version "17.0.0"
-  dependencies:
-    eslint-config-airbnb-base "^13.0.0"
-    object.assign "^4.1.0"
-    object.entries "^1.0.4"
+    eslint-config-airbnb-base "^12.1.0"
 
 eslint-config-prettier@^2.9.0:
   version "2.9.0"
@@ -3213,7 +3203,7 @@ fsevents@^1.2.2, fsevents@^1.2.3:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-function-bind@^1.1.0, function-bind@^1.1.1:
+function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -5073,7 +5063,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.11, object-keys@^1.0.8:
+object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
@@ -5082,24 +5072,6 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
-
-object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
-
-object.entries@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.6.1"
-    function-bind "^1.1.0"
-    has "^1.0.1"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
I noticed that airbnb released new version these days https://github.com/airbnb/javascript/releases , it will break eslint on this repository. I've tried on circle CI. see this, https://circleci.com/gh/VeryBuy/react-native-router-flux/1

It is more reliable if 3rd package is fixed version, so I fixed airbnb-style version to 16.1.0 and fix the lint style.