### PR TITLE
add Statusbar marginTop for navTransparent

### DIFF
--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, Animated, Easing } from 'react-native';
+import { Statusbar, Image, Animated, Easing } from 'react-native';
 import {
   createBottomTabNavigator,
   createMaterialTopTabNavigator,
@@ -326,7 +326,7 @@ function createNavigationOptions(params) {
 
     if (navTransparent) {
       res.headerTransparent = true;
-      res.headerStyle = {};
+      res.headerStyle = { marginTop: StatusBar.currentHeight };
     }
 
     if (backToInitial) {

--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Statusbar, Image, Animated, Easing } from 'react-native';
+import { StatusBar, Image, Animated, Easing } from 'react-native';
 import {
   createBottomTabNavigator,
   createMaterialTopTabNavigator,


### PR DESCRIPTION
When using navTransparent feature, the headerStyle is removed causing the navbar to be obstructed by the Statusbar. 

This fix adds marginTop to the headerStyle to that the navbar is aligned below the Statusbar.