### PR TITLE
Add title to StackProps type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,8 @@ interface StackProps extends React.Props<Stack> {
     icon?: any;
     tintColor?: string;
     hideNavBar?: boolean;
-    titleStyle?: StyleProp<TextStyle>;                                               
+    title?: string;
+    titleStyle?: StyleProp<TextStyle>;
 }
 interface StackStatic extends React.ComponentClass<StackProps> {
 }


### PR DESCRIPTION
The Stack component supports a title property. This updates typescript definitions to match.