### PR TITLE
fixes Actions.reset when getParent returns null

### DIFF
--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -919,11 +919,11 @@ class NavigationStore {
 
   reset = (routeName, data) => {
     const params = filterParam(data);
-    const { key } = getParent(this.state, routeName);
+    const parent = getParent(this.state, routeName);
     this.dispatch(
       StackActions.reset({
         index: 0,
-        key,
+        key: parent ? parent.key : null,
         actions: [
           NavigationActions.navigate({
             routeName,


### PR DESCRIPTION
Hey,

I currently don't have time to dig deep into this library so I'm not 100% sure if it makes sense what I did but what happened to me after using master branch to get the fix for #3176 was the following:

JSX was:
```
<Router key='router'>
  <Modal onRequestClose={() => { }} key='modal'>
    <Lightbox key='lightbox' hideNavBar>
      <Scene key='root' hideNavBar>
        <Scene key='splash' component={Splash} hideNavBar/>
        [...]
      </Scene>
    </Lightbox>
    <Scene key='configuration' component={InitConfiguration} hideNavBar/>
  </Modal>
</Router>
```

The console output from this.state() inside the _reset_ method called from 'initConfiguration'-screen was:
```
{ key: 'StackRouterRoot',
   routes:
     [ { params: { isInitialNavigation: true },
          routeName: 'configuration',
          key: 'id-1536232996974-7' } ],
      index: 0,
      isTransitioning: false }
```

Due to this combination the getParent([...]) call inside the _reset_ method returned null which lead to a 'null is not an object' error while accessing the 'key' property.
