### PR TITLE
fix: add right title to ts definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,7 @@ interface SceneProps extends React.Props<Scene> {
   renderLeftButton?: React.ComponentType<any>;
   renderRightButton?: React.ComponentType<any>;
   renderBackButton?: React.ComponentType<any>;
+  rightTitle?: string;
   rightButtonImage?: Image;
   rightButtonTextStyle?: StyleProp<TextStyle>;
   success?: (() => void) | string;


### PR DESCRIPTION
TS definition lacks of rightTitle on the definition of Scene.