### PR TITLE
Add basic test for react-native example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,3 +21,11 @@ jobs:
       - run:
           name: linter
           command: yarn lint
+      - run:
+          name: install-dependencies react-native example
+          command: yarn install --frozen-lockfile
+          working_directory: ~/react-native-router-flux/examples/react-native
+      - run:
+          name: test react-native example
+          command: yarn test
+          working_directory: ~/react-native-router-flux/examples/react-native

--- a/examples/react-native/__tests__/Example.test.js
+++ b/examples/react-native/__tests__/Example.test.js
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { render } from 'react-native-testing-library';
+
+import Example from '../Example';
+
+test('Example renders successfully', () => {
+  expect(() => {
+    render(<Example />);
+  }).not.toThrow();
+});

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -35,6 +35,7 @@
     "babel-jest": "^23.6.0",
     "jest": "^23.6.0",
     "metro-react-native-babel-preset": "^0.45.0",
+    "react-native-testing-library": "1.4.2",
     "react-test-renderer": "16.5.2",
     "schedule": "0.4.0"
   },

--- a/examples/react-native/yarn.lock
+++ b/examples/react-native/yarn.lock
@@ -4264,6 +4264,13 @@ react-native-tab-view@^1.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-native-testing-library@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/react-native-testing-library/-/react-native-testing-library-1.4.2.tgz#6d9005e4215701ae68659d1f53bce02c88dd5784"
+  integrity sha512-nG4v0a2styrDbObc/aQzzXpGpSLbvsZEv23ixz+mmDQzWjzAbL3Gu5gZYvHz03U4mZzdHN7QuEVL3QrYyFSwrQ==
+  dependencies:
+    pretty-format "^23.6.0"
+
 react-native@0.57.1:
   version "0.57.1"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.57.1.tgz#a8bffeac13e200b95bbebd11f7131570902e1e74"


### PR DESCRIPTION
Simply checks whether rendering the example throws, to avoid something like https://github.com/aksonov/react-native-router-flux/pull/3380 in the future.

(I haven't used CircleCI before though, so I don't know whether the config will work like that and for some reason, I can't try it out on the branch of my fork...)