### PR TITLE
Update API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -207,7 +207,7 @@ These can be used directly, for example, `Actions.pop()` will dispatch correspon
 | Property | Type | Parameters | Description |
 |-----------------|----------|----------|--------------------------------------------|
 | `[key]` | `Function` | `Object` | The `Actions` object "automagically" uses the `Scene`'s `key` prop in the `Router` to navigate. To navigate to a scene, call `Actions.key()` or `Actions[key].call()`. |
-| `create` | `React.Element` | pass `Scene` to create your app navigator. It is alternative router creation method mostly used for Redux integration |
+| `create` | `React.Element` | `(rootScene: Scene, props: Object, wrapBy: Function)` | pass `Scene` to create your app navigator and the Props the Router should receive. It is alternative router creation method mostly used for Redux integration |
 | `currentScene` | `String` | | Returns the current scene that is active |
 | `drawerClose` | `Function` | | Closes the `Drawer` if applicable |
 | `drawerOpen` | `Function` | | Opens the `Drawer` if applicable |


### PR DESCRIPTION
update Documentation for `Actions.create(...)` to include the props and wrap by arguments.
Found this out while trying to set a sceneStyle on my Router via `getSceneStyle`. This prop is ignored if the navigator is set directly on the router, this might be a bug. 
If i supply the cardstyle to `Actions.create( ... , { cardStyle: { ... } }` it is working fine so the Documentation should mention this.