### PR TITLE
fix: add SceneProps to TabsStatic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,7 @@ interface TabsProps extends React.Props<Tabs> {
   tabBarOnPress?: Function;
   backToInitial?: boolean;
 }
-interface TabsStatic extends React.ComponentClass<TabsProps> {}
+interface TabsStatic extends React.ComponentClass<SceneProps & TabsProps> {}
 export type TabBarPositionType = 'top' | 'bottom';
 
 // Drawer


### PR DESCRIPTION
Per documentation, `<Tabs>` should receive the same props as `<Scene>` and is the same as `<Scene tabs>`, however, the prop type doesn't currently include SceneProps.

This adds SceneProps to TabStatic as is currently done with ModalStatic and DrawerStatic.