### PR TITLE
update postinstall so that it doesn't cause failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "types": "index.d.ts",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
-    "postinstall": "./node_modules/.bin/opencollective postinstall",
+    "postinstall": "./node_modules/.bin/opencollective postinstall || exit 0",
     "build": "./node_modules/.bin/babel src -d dist",
     "lint": "prettier-eslint src/**/*.js __tests__/**/*.js --list-different",
     "fix": "prettier-eslint src/**/*.js __tests__/**/*.js --write",


### PR DESCRIPTION
There are a few known scenarios where the opencollective postinstall npm script can cause things to break further down the pipeline - a few being 'certain build/CI environments', 'script permission issues' and 'offline installs'.... 

Ultimately, at the heart of the failure, is a non 0 exit code being returned in the cases that opencollective fails to properly execute. 

To prevent this non-zero exit code failure so that subsequent npm processes aren't disrupted as a result of non-functional dependency issues, a "|| exit 0" should be added to the postinstall npm script.