### PR TITLE
[revert] remove Statusbar marginTop for navTransparent

### DIFF
--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  StatusBar, Image, Animated, Easing,
+  Image, Animated, Easing,
 } from 'react-native';
 import {
   createAppContainer,
@@ -346,7 +346,6 @@ function createNavigationOptions(params) {
 
     if (navTransparent) {
       res.headerTransparent = true;
-      res.headerStyle = { marginTop: StatusBar.currentHeight };
     }
 
     if (!legacy && backToInitial) {

--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  Image, Animated, Easing,
-} from 'react-native';
+import { Image, Animated, Easing } from 'react-native';
 import {
   createAppContainer,
   createBottomTabNavigator,

--- a/src/navigationStore.js
+++ b/src/navigationStore.js
@@ -346,6 +346,7 @@ function createNavigationOptions(params) {
 
     if (navTransparent) {
       res.headerTransparent = true;
+      res.headerStyle = {};
     }
 
     if (!legacy && backToInitial) {


### PR DESCRIPTION
- revert #3212 

## Reason
Status bar can be overlay to screen(app will draw under the status bar), It is not odd behavior..
Transplucent status bar is default in iOS(cli, expo) and Android(expo)
But Android(cli) not default option, it just can be set by translucent of 'StatusBar'

If user want to status bar overlay to screen, they must use 'SafeAreaView' but this working only in iOS, because that concept doesn't exist on Android.
for this reason, not margin top to navigation in RNRF but padding top to screen(or wrapping routes with OverlayStatusBarView) by user self

please see the example code

```
import {SafeAreaView, StatusBar, Platform } from 'react-native';

const OverlayStatusBarView = (props) => {
    const {children, style, ...rest} = props;
    return(
      <SafeAreaView 
        style={[{paddingTop: StatusBar.currentHeight},style]}
        {...rest}
      >
        <StatusBar translucent /> 
        {children}
      </SafeAreaView>
    )
}
```