### PR TITLE
[examples/react-native] Fix drawer does not close for Android

### DIFF
--- a/examples/react-native/android/app/src/main/java/com/example/MainActivity.java
+++ b/examples/react-native/android/app/src/main/java/com/example/MainActivity.java
@@ -1,6 +1,9 @@
 package com.example;
 
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 
 public class MainActivity extends ReactActivity {
 
@@ -11,5 +14,15 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "Example";
+    }
+
+    @Override
+    protected ReactActivityDelegate createReactActivityDelegate() {
+      return new ReactActivityDelegate(this, getMainComponentName()) {
+        @Override
+        protected ReactRootView createRootView() {
+          return new RNGestureHandlerEnabledRootView(MainActivity.this);
+        }
+      };
     }
 }


### PR DESCRIPTION
After upgrading to react-native-router-flux@4.2.0.
Drawer does not close on Android.
I looked into you example app.
It has the same bug.
Same as described here: https://github.com/react-navigation/react-navigation/issues/5508

I can't run your example app so I tested it with the PR here https://github.com/aksonov/react-native-router-flux/pull/3610.