### PR TITLE
FIX-TS-def adding addRef definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -164,6 +164,7 @@ interface ActionsStatic {
   refresh: (props?: any) => void;
   replace: (sceneKey: string, props?: any) => void;
   reset: (sceneKey: string, props?: any) => void;
+  addRef: (name: string, ref?: any) => void
   drawerOpen?: any;
   drawerClose?: any;
 }


### PR DESCRIPTION
simple fix to avoid TS error message on `Action.addRef()` currently it says that function receives only one param, but actually it receives two as we can see on `navigationStore.js` file

`navigationStore.js` file
<img width="446" alt="image" src="https://user-images.githubusercontent.com/10479750/110184843-d6823000-7dde-11eb-8958-5aabee1ce9f3.png">

Error:
<img width="904" alt="image" src="https://user-images.githubusercontent.com/10479750/110184075-4217cd80-7dde-11eb-8614-1b0a8c131170.png">
<img width="529" alt="image" src="https://user-images.githubusercontent.com/10479750/110184774-b2beea00-7dde-11eb-8c67-678c35cb985f.png">

No more issue after fixed:
![image](https://user-images.githubusercontent.com/10479750/110184677-7a1f1080-7dde-11eb-8639-5593897497c0.png)
