### PR TITLE
delete and replace ViewPropTypes with PropTypes 🚀

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ViewPropTypes, BackHandler, Linking } from 'react-native';
+import { BackHandler, Linking } from 'react-native';
 import PropTypes from 'prop-types';
 import NavigationStore from './Store';
 import defaultStore from './defaultStore';
@@ -132,7 +132,7 @@ Router.propTypes = {
   navigator: PropTypes.func,
   wrapBy: PropTypes.func,
   getSceneStyle: PropTypes.func,
-  sceneStyle: ViewPropTypes.style,
+  sceneStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   createReducer: PropTypes.func,
   children: PropTypes.element,
   uriPrefix: PropTypes.string,


### PR DESCRIPTION
- Updating react-native-router-flux in response to deprecated 'ViewPropTypes' usage within react-native-web package
- 'ViewPropTypes...' is replaced with 'PropTypes...' for these updates

(see ADO -> Work Items ID 18471 -> Child Tasks for more details)